### PR TITLE
Support for 4-connected-neighbor island detection

### DIFF
--- a/UVtools.Core/Layer/LayerIssue.cs
+++ b/UVtools.Core/Layer/LayerIssue.cs
@@ -52,6 +52,15 @@ namespace UVtools.Core
         /// Gets the required brightness of supporting pixels to count as a valid support (0-255)
         /// </summary>
         public byte RequiredPixelBrightnessToSupport { get; set; } = 150;
+
+        /// <summary>
+        /// Gets the setting for whether or not diagonal bonds are considered when evaluation islands.
+        /// If true, all 8 neighbors of a pixel (including diagonals) will be considered when finding
+        /// individual components on the layer, if false only 4 neighbors (right, left, above, below)
+        /// will be considered..
+        /// </summary>
+        /// 
+        public bool AllowDiagonalBonds  { get; set; } = false;
     }
 
     public class ResinTrapDetectionConfiguration


### PR DESCRIPTION
This commit adds the ability to use the  4-connected neighbor approach rather than the 8-connected neighbor approach when
finding components in a layer during island evaluation.  This allows individual pixels or groups of pixels that are only touching on the diagonal of a single pixel to be evaluated independently for their island status rather than being treated as a single component.

This commit replaces the calls to findContour and drawContour in LayerManger with a call to connectedComponents, and updates the supporting logic to work with connectedComponents.  Only the section of the code dealing specifically with island
detection has been updated, so areas dealing with resinTraps, for example, still rely on findContour and drawContour, though, in theory, connectedComponets would also work for these sections of the code.

A function for AllowDiagonalBonds has also been added to the islandDetectionConfig in LayerIssues, but this config item
has not been plumbed up into the GUI as part of this commit. Changing the default value of AllowDiagonalBonds from false to true in this code will result in equivalent island detection to what existed prior to this commit, albeit via slightly different logic.

NOTE:  Using kdiff3 in my local environment gave a nice clean diff, which did a good job of representing the sections of code I didn't modify interleaved with those I did.  Github  diff doesn't seem to do as good a job aligning existing code between the baseline and my commit.