### PR TITLE
Display hand cursor in select mode

### DIFF
--- a/UVtools.GUI/FrmMain.cs
+++ b/UVtools.GUI/FrmMain.cs
@@ -3097,10 +3097,10 @@ namespace UVtools.GUI
 
                 // Pixel Edit is active, Shift is down, and the cursor is over the image region.
                 if (e.KeyCode == Keys.ShiftKey &&
-                    pbLayer.ClientRectangle.Contains(pbLayer.PointToClient(MousePosition)) &&
-                    tsLayerImagePixelEdit.Checked)
+                    pbLayer.ClientRectangle.Contains(pbLayer.PointToClient(MousePosition)))
                 {
-                    pbLayer.Cursor = Cursors.Cross;
+
+                    pbLayer.Cursor = tsLayerImagePixelEdit.Checked ? Cursors.Cross : Cursors.Hand;
                     pbLayer.PanMode = Cyotek.Windows.Forms.ImageBoxPanMode.None;
                     if (!ReferenceEquals(SlicerFile, null)) ShowLayer();
                 }


### PR DESCRIPTION
Cursor is changed to hand on SHIFT key, and pan mode
is also temporarily disabled.  Releasing SHIFT restores
default behavior.