### PR TITLE
Change Zoom Level Lock to middle mouse click-hold

### DIFF
--- a/UVtools.GUI/FrmMain.Designer.cs
+++ b/UVtools.GUI/FrmMain.Designer.cs
@@ -257,6 +257,7 @@
             this.issueScrollTimer = new System.Windows.Forms.Timer(this.components);
             this.toolTipInformation = new System.Windows.Forms.ToolTip(this.components);
             this.layerScrollTimer = new System.Windows.Forms.Timer(this.components);
+            this.mouseHoldTimer = new System.Windows.Forms.Timer(this.components);
             this.menu.SuspendLayout();
             this.mainTable.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.scCenter)).BeginInit();
@@ -330,7 +331,7 @@
             this.menuNewVersion});
             this.menu.Location = new System.Drawing.Point(0, 0);
             this.menu.Name = "menu";
-            this.menu.Size = new System.Drawing.Size(1784, 24);
+            this.menu.Size = new System.Drawing.Size(1732, 24);
             this.menu.TabIndex = 0;
             this.menu.Text = "menuStrip1";
             // 
@@ -632,7 +633,7 @@
             // 
             this.statusBar.Location = new System.Drawing.Point(0, 789);
             this.statusBar.Name = "statusBar";
-            this.statusBar.Size = new System.Drawing.Size(1784, 22);
+            this.statusBar.Size = new System.Drawing.Size(1732, 22);
             this.statusBar.TabIndex = 1;
             this.statusBar.Text = "statusStrip1";
             // 
@@ -650,7 +651,7 @@
             this.mainTable.Name = "mainTable";
             this.mainTable.RowCount = 1;
             this.mainTable.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.mainTable.Size = new System.Drawing.Size(1784, 765);
+            this.mainTable.Size = new System.Drawing.Size(1732, 765);
             this.mainTable.TabIndex = 5;
             // 
             // scCenter
@@ -671,7 +672,7 @@
             // 
             this.scCenter.Panel2.Controls.Add(this.tsLayerInfo);
             this.scCenter.Panel2MinSize = 18;
-            this.scCenter.Size = new System.Drawing.Size(1228, 759);
+            this.scCenter.Size = new System.Drawing.Size(1176, 759);
             this.scCenter.SplitterDistance = 730;
             this.scCenter.TabIndex = 4;
             // 
@@ -684,11 +685,12 @@
             this.pbLayer.Name = "pbLayer";
             this.pbLayer.PanMode = Cyotek.Windows.Forms.ImageBoxPanMode.Left;
             this.pbLayer.ShowPixelGrid = true;
-            this.pbLayer.Size = new System.Drawing.Size(1228, 705);
+            this.pbLayer.Size = new System.Drawing.Size(1176, 705);
             this.pbLayer.TabIndex = 7;
             this.pbLayer.Zoomed += new System.EventHandler<Cyotek.Windows.Forms.ImageBoxZoomEventArgs>(this.pbLayer_Zoomed);
             this.pbLayer.MouseClick += new System.Windows.Forms.MouseEventHandler(this.EventMouseClick);
             this.pbLayer.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.EventMouseDoubleClick);
+            this.pbLayer.MouseDown += new System.Windows.Forms.MouseEventHandler(this.pbLayer_MouseDown);
             this.pbLayer.MouseMove += new System.Windows.Forms.MouseEventHandler(this.pbLayer_MouseMove);
             this.pbLayer.MouseUp += new System.Windows.Forms.MouseEventHandler(this.pbLayer_MouseUp);
             // 
@@ -713,7 +715,7 @@
             this.tsLayerClone});
             this.tsLayer.Location = new System.Drawing.Point(0, 0);
             this.tsLayer.Name = "tsLayer";
-            this.tsLayer.Size = new System.Drawing.Size(1228, 25);
+            this.tsLayer.Size = new System.Drawing.Size(1176, 25);
             this.tsLayer.TabIndex = 6;
             this.tsLayer.Text = "Layer Menu";
             // 
@@ -930,7 +932,7 @@
             this.tsLayerBounds});
             this.tsLayerInfo.Location = new System.Drawing.Point(0, 0);
             this.tsLayerInfo.Name = "tsLayerInfo";
-            this.tsLayerInfo.Size = new System.Drawing.Size(1228, 25);
+            this.tsLayerInfo.Size = new System.Drawing.Size(1176, 25);
             this.tsLayerInfo.TabIndex = 9;
             this.tsLayerInfo.Text = "tsLayerInfo";
             // 
@@ -2681,7 +2683,7 @@
             this.tlRight.Controls.Add(this.lbInitialLayer, 0, 5);
             this.tlRight.Controls.Add(this.panel2, 0, 4);
             this.tlRight.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tlRight.Location = new System.Drawing.Point(1637, 3);
+            this.tlRight.Location = new System.Drawing.Point(1585, 3);
             this.tlRight.Name = "tlRight";
             this.tlRight.RowCount = 6;
             this.tlRight.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 50F));
@@ -2851,12 +2853,17 @@
             this.layerScrollTimer.Interval = 500;
             this.layerScrollTimer.Tick += new System.EventHandler(this.EventTimerTick);
             // 
+            // mouseHoldTimer
+            // 
+            this.mouseHoldTimer.Interval = 1000;
+            this.mouseHoldTimer.Tick += new System.EventHandler(this.EventTimerTick);
+            // 
             // FrmMain
             // 
             this.AllowDrop = true;
             this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 18F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1784, 811);
+            this.ClientSize = new System.Drawing.Size(1732, 811);
             this.Controls.Add(this.mainTable);
             this.Controls.Add(this.statusBar);
             this.Controls.Add(this.menu);
@@ -3191,6 +3198,7 @@
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator24;
         private System.Windows.Forms.ToolStripLabel tsLayerImageZoomLock;
         private System.Windows.Forms.ToolStripButton btnGCodeRebuild;
+        private System.Windows.Forms.Timer mouseHoldTimer;
     }
 }
 

--- a/UVtools.GUI/FrmMain.cs
+++ b/UVtools.GUI/FrmMain.cs
@@ -1963,8 +1963,18 @@ namespace UVtools.GUI
             }
         }
 
+        private void pbLayer_MouseDown(object sender, MouseEventArgs e)
+        {
+            mouseHoldTimer.Tag = e.Button;
+            mouseHoldTimer.Start();
+        }
+
         private void pbLayer_MouseUp(object sender, MouseEventArgs e)
         {
+
+            // unconditionally stop any pending mouse timer here.
+            mouseHoldTimer.Stop();
+
             // Shift must be pressed for any pixel edit action, middle button is ignored.
             if (!tsLayerImagePixelEdit.Checked || (e.Button & MouseButtons.Middle) != 0 || 
                 (ModifierKeys & Keys.Shift) == 0) return;
@@ -3332,6 +3342,25 @@ namespace UVtools.GUI
                 }
                 return;
             }
+
+            if (ReferenceEquals(sender, mouseHoldTimer))
+            {
+                mouseHoldTimer.Stop();  // one-shot timer
+
+                if ((MouseButtons)mouseHoldTimer.Tag == MouseButtons.Middle)
+                {
+                    // Reset auto-zoom level based on current zoom level and
+                    // refresh toolstrip zoom indicator.
+                    var currentBackIndex = ConvZoomToBackIndex(pbLayer.Zoom);
+                    // Don't allow small zoom values to be locked for auto-zoom
+                    if (currentBackIndex >= ZoomLevels.Length - ZoomLevelSkipCount) return;
+                    AutoZoomBackIndex = currentBackIndex;
+                    tsLayerImageZoom.Text = $"Zoom: [ {pbLayer.Zoom / 100f}x";
+                    tsLayerImageZoomLock.Visible = true;
+                }
+                return;
+            }
+
         }
 
         private void EventMouseClick(object sender, MouseEventArgs e)
@@ -3402,18 +3431,6 @@ namespace UVtools.GUI
                     // Check to see if the clicked location is an issue, and if so, select it in the ListView.
                     SelectIssueAtPoint(location);
 
-                    return;
-                }
-                if ((e.Button & MouseButtons.Middle) != 0)
-                {
-                    // Reset auto-zoom level based on current zoom level and
-                    // refresh toolstrip zoom indicator.
-                    var currentBackIndex = ConvZoomToBackIndex(pbLayer.Zoom);
-                    // Don't allow small zoom values to be locked for auto-zoom
-                    if (currentBackIndex >= ZoomLevels.Length - ZoomLevelSkipCount) return;
-                    AutoZoomBackIndex = currentBackIndex;
-                    tsLayerImageZoom.Text = $"Zoom: [ {pbLayer.Zoom / 100f}x";
-                    tsLayerImageZoomLock.Visible = true;
                     return;
                 }
                 if ((e.Button & MouseButtons.Right) != 0)

--- a/UVtools.GUI/FrmMain.resx
+++ b/UVtools.GUI/FrmMain.resx
@@ -152,7 +152,7 @@
         AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
         LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAACZTeXN0
         ZW0uV2luZG93cy5Gb3Jtcy5JbWFnZUxpc3RTdHJlYW1lcgEAAAAERGF0YQcCAgAAAAkDAAAADwMAAABk
-        FAAAAk1TRnQBSQFMAgEBBgEAAVABCQFQAQkBEAEAARABAAT/ASEBAAj/AUIBTQE2BwABNgMAASgDAAFA
+        FAAAAk1TRnQBSQFMAgEBBgEAAXABCQFwAQkBEAEAARABAAT/ASEBAAj/AUIBTQE2BwABNgMAASgDAAFA
         AwABIAMAAQEBAAEgBgABIC4AAxgBIgMwAUsDMAFMAzIBUDMAAQEDJAE2AysBQqwAAyIBMQNWAbkDXQHi
         AwAB/wMAAf8BKgEtASgB/gNTAawDTQGVAwABARgAAwkBDAMzAVIDUAGdA1cB6AMAAf4DKwH8Ay8BSqQA
         AyEBMANZAewBKwEuASkB+gNRAfcDUgH0A1MB8QNIAfYDQQH5AwAB/wNPAZsDAAEBCAADFQEdAz8BbgNV
@@ -200,7 +200,7 @@
         BAADUgGpAzQBVQM0AVUgAAM0AVUDNAFVA1IBqQgAA0oBiwMAAf8DAAH/A08BnAQAA00BlQMAAf8DVAGr
         CAADTwGcAwAB/wMAAf8DSgGLBAADUQGgAQABzAH3Af8BAAHMAfcB/wEAAcwB9wH/AQABzAH3Af8DQwF3
         CAADSgGNAgAB7AH/AgAB7AH/AgAB7wH/AgAB7AH/AgAB7AH/AgAB7QH/AVICUwGoA1IBqAMAAf8DAAH/
-        AwAB/wNRAfcDMQH9A1ABnwsAAf8DAAH/AwAB/wMAAf8DAAH/AwAB/wNSAagEAANSAakDNAFVAzQBVQNG
+        AwAB/wNRAfcDNQH9A1ABnwsAAf8DAAH/AwAB/wMAAf8DAAH/AwAB/wNSAagEAANSAakDNAFVAzQBVQNG
         AYADUgGpA1IBqQNSAakDUgGpA1IBqQNSAakDRQF/AzQBVQM0AVUDUgGpBAADUQGiAwAB/wMAAf8DSQGJ
         CAADLwFKAwAB/wNUAe4MAANJAYkDAAH/AwAB/wNRAaIDAAEBAT8CQAFvAT4CXAH4AQABzQH3Af8BAAHN
         AfcB/wMSARgIAAMBAQIDRgF+AlIBXQHwAgAB7gH/AgAB7gH/AkABqAH9AUUCRgF+AwMBBANSAagDAAH/
@@ -277,6 +277,12 @@
   </metadata>
   <metadata name="layerScrollTimer.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>1292, 17</value>
+  </metadata>
+  <metadata name="mouseHoldTimer.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 56</value>
+  </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>253</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">


### PR DESCRIPTION
Locking the auto-zoom level is now tied to click-hold of the
middle mouse button for 1 seconds rather than double-click
on middle mouse button.

This helps with accidental scrolling, as the middles mouse
button can sometimes be difficult to use.  Press-hold is
less error prone in this respect than double-click.