### PR TITLE
Limit mouseHoldTimer to middle mouse button

### DIFF
--- a/UVtools.GUI/FrmMain.Designer.cs
+++ b/UVtools.GUI/FrmMain.Designer.cs
@@ -973,7 +973,7 @@
             this.tsLayerImageZoomLock.Size = new System.Drawing.Size(27, 22);
             this.tsLayerImageZoomLock.Text = "]";
             this.tsLayerImageZoomLock.ToolTipText = "This zoom factor will be used for auto-zoom functions. Use scroll wheel to select" +
-    " desired auto zoom level\r\nand double-click middle mouse button to set.";
+    " desired auto zoom level\r\nand hold middle mouse button for 1 second to set.";
             this.tsLayerImageZoomLock.Visible = false;
             // 
             // tsLayerImageZoom

--- a/UVtools.GUI/FrmMain.cs
+++ b/UVtools.GUI/FrmMain.cs
@@ -1965,8 +1965,11 @@ namespace UVtools.GUI
 
         private void pbLayer_MouseDown(object sender, MouseEventArgs e)
         {
-            mouseHoldTimer.Tag = e.Button;
-            mouseHoldTimer.Start();
+            if (e.Button == MouseButtons.Middle)
+            {
+                mouseHoldTimer.Tag = e.Button;
+                mouseHoldTimer.Start();
+            }
         }
 
         private void pbLayer_MouseUp(object sender, MouseEventArgs e)


### PR DESCRIPTION
Tooltip is also updated to indicate middlemouse hold vs. double-click