### PR TITLE
Fix Issue List update on Layer Preview Select

### DIFF
--- a/UVtools.GUI/FrmMain.cs
+++ b/UVtools.GUI/FrmMain.cs
@@ -3414,7 +3414,7 @@ namespace UVtools.GUI
                     // Not needed? visual artifact is not severe to make an extra showlayer call, also it acts like an "animation" removing crosshairs after zoom
                     /*if (tsLayerImageShowCrosshairs.Checked &&
                         !ReferenceEquals(Issues, null) && flvIssues.SelectedIndices.Count > 0 && 
-                        pbLayer.Zoom <= CrosshairFadeLevel && AutoZoomLevel > CrosshairFadeLevel &&
+                        pbLayer.Zoom <= CrosshairFadeLevel && LockedZoomLevel > CrosshairFadeLevel &&
                         flvIssues.SelectedObjects.Cast<LayerIssue>().Any(issue => // Find a valid candidate to update layer preview, otherwise quit
                         issue.LayerIndex == ActualLayer && issue.Type != LayerIssue.IssueType.EmptyLayer && issue.Type != LayerIssue.IssueType.TouchingBound))
                     {
@@ -4071,7 +4071,7 @@ namespace UVtools.GUI
             {
                 // Check to see if this zoom action will cross the crosshair fade threshold
                 /*if (tsLayerImageShowCrosshairs.Checked && !ReferenceEquals(Issues, null) && flvIssues.SelectedIndices.Count > 0
-                   && pbLayer.Zoom <= CrosshairFadeLevel && AutoZoomLevel > CrosshairFadeLevel)
+                   && pbLayer.Zoom <= CrosshairFadeLevel && LockedZoomLevel > CrosshairFadeLevel)
                 {
                     // Refresh the preview without the crosshairs before zooming-in.
                     // Prevents zoomed-in crosshairs from breifly being displayed before
@@ -4145,6 +4145,7 @@ namespace UVtools.GUI
 
                 flvIssues.SelectedIndex = index;
                 flvIssues.EnsureVisible(index);
+                flvIssues.Refresh();
                 break;
             }
 


### PR DESCRIPTION
When selecting issues using SHIFT in the layer preview, the selected issue doesn't update in the issue list until after shift is released.  This fix forces an immediate refresh of the issue list so that it updates as you click on issues in the layer preview rather than after SHIFT is released.

Also fixed some commented code for for clearing crosshairs before zoom so that it compiles when un-commented...but code
is still commented out in the commit.