### PR TITLE
Settings Dialog Refresh

### DIFF
--- a/UVtools.GUI/App.config
+++ b/UVtools.GUI/App.config
@@ -231,7 +231,7 @@
       <setting name="CrosshairLineMargin" serializeAs="String">
         <value>5</value>
       </setting>
-      <setting name="CrossharirColor" serializeAs="String">
+      <setting name="CrosshairColor" serializeAs="String">
         <value>Red</value>
       </setting>
       <setting name="ZoomIssuesAuto" serializeAs="String">

--- a/UVtools.GUI/Forms/FrmSettings.Designer.cs
+++ b/UVtools.GUI/Forms/FrmSettings.Designer.cs
@@ -30,44 +30,11 @@
         {
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FrmSettings));
-            this.label1 = new System.Windows.Forms.Label();
-            this.btnPreviousNextLayerColor = new System.Windows.Forms.Button();
             this.colorDialog = new System.Windows.Forms.ColorDialog();
-            this.btnPreviousLayerColor = new System.Windows.Forms.Button();
-            this.label2 = new System.Windows.Forms.Label();
-            this.btnNextLayerColor = new System.Windows.Forms.Button();
-            this.label3 = new System.Windows.Forms.Label();
-            this.btnTouchingBoundsColor = new System.Windows.Forms.Button();
-            this.label4 = new System.Windows.Forms.Label();
-            this.label5 = new System.Windows.Forms.Label();
-            this.label6 = new System.Windows.Forms.Label();
-            this.btnResinTrapColor = new System.Windows.Forms.Button();
-            this.btnResinTrapHLColor = new System.Windows.Forms.Button();
-            this.btnIslandColor = new System.Windows.Forms.Button();
-            this.btnIslandHLColor = new System.Windows.Forms.Button();
             this.btnSave = new System.Windows.Forms.Button();
             this.btnCancel = new System.Windows.Forms.Button();
             this.cbCheckForUpdatesOnStartup = new System.Windows.Forms.CheckBox();
             this.cbStartMaximized = new System.Windows.Forms.CheckBox();
-            this.cbZoomToFitPrintVolumeBounds = new System.Windows.Forms.CheckBox();
-            this.cbOutlineHollowAreas = new System.Windows.Forms.CheckBox();
-            this.label18 = new System.Windows.Forms.Label();
-            this.nmOutlineHollowAreasLineThickness = new System.Windows.Forms.NumericUpDown();
-            this.label19 = new System.Windows.Forms.Label();
-            this.btnOutlineHollowAreasColor = new System.Windows.Forms.Button();
-            this.cbOutlineLayerBounds = new System.Windows.Forms.CheckBox();
-            this.label16 = new System.Windows.Forms.Label();
-            this.nmOutlineLayerBoundsLineThickness = new System.Windows.Forms.NumericUpDown();
-            this.label17 = new System.Windows.Forms.Label();
-            this.btnOutlineLayerBoundsColor = new System.Windows.Forms.Button();
-            this.cbOutlinePrintVolumeBounds = new System.Windows.Forms.CheckBox();
-            this.label15 = new System.Windows.Forms.Label();
-            this.nmOutlinePrintVolumeBoundsLineThickness = new System.Windows.Forms.NumericUpDown();
-            this.label14 = new System.Windows.Forms.Label();
-            this.btnOutlinePrintVolumeBoundsColor = new System.Windows.Forms.Button();
-            this.cbLayerZoomToFit = new System.Windows.Forms.CheckBox();
-            this.cbLayerDifferenceDefault = new System.Windows.Forms.CheckBox();
-            this.cbLayerAutoRotateBestView = new System.Windows.Forms.CheckBox();
             this.cbComputeIssuesOnLoad = new System.Windows.Forms.CheckBox();
             this.btnReset = new System.Windows.Forms.Button();
             this.cbComputeIslands = new System.Windows.Forms.CheckBox();
@@ -94,11 +61,13 @@
             this.label8 = new System.Windows.Forms.Label();
             this.nmIslandRequiredPixelBrightnessToProcessCheck = new System.Windows.Forms.NumericUpDown();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.cbComputeEmptyLayers = new System.Windows.Forms.CheckBox();
             this.label42 = new System.Windows.Forms.Label();
             this.cbComputeTouchingBounds = new System.Windows.Forms.CheckBox();
             this.cbAutoComputeIssuesClickOnTab = new System.Windows.Forms.CheckBox();
             this.tabSettings = new System.Windows.Forms.TabControl();
             this.tabPage1 = new System.Windows.Forms.TabPage();
+            this.groupBox4 = new System.Windows.Forms.GroupBox();
             this.groupBox5 = new System.Windows.Forms.GroupBox();
             this.btnFileExtractDefaultDirectoryClear = new System.Windows.Forms.Button();
             this.btnFileExtractDefaultDirectorySearch = new System.Windows.Forms.Button();
@@ -123,24 +92,63 @@
             this.tbFileSaveNameSuffix = new System.Windows.Forms.TextBox();
             this.label27 = new System.Windows.Forms.Label();
             this.tbFileSaveNamePreffix = new System.Windows.Forms.TextBox();
-            this.groupBox4 = new System.Windows.Forms.GroupBox();
             this.tabPage2 = new System.Windows.Forms.TabPage();
-            this.cbZoomIssuesAuto = new System.Windows.Forms.CheckBox();
-            this.label40 = new System.Windows.Forms.Label();
-            this.label41 = new System.Windows.Forms.Label();
-            this.nmCrosshairLineMargin = new System.Windows.Forms.NumericUpDown();
-            this.label39 = new System.Windows.Forms.Label();
+            this.groupBox6 = new System.Windows.Forms.GroupBox();
+            this.label1 = new System.Windows.Forms.Label();
+            this.label2 = new System.Windows.Forms.Label();
+            this.cbOutlineHollowAreas = new System.Windows.Forms.CheckBox();
+            this.btnPreviousNextLayerColor = new System.Windows.Forms.Button();
+            this.btnPreviousLayerColor = new System.Windows.Forms.Button();
+            this.label18 = new System.Windows.Forms.Label();
+            this.btnIslandColor = new System.Windows.Forms.Button();
+            this.btnIslandHLColor = new System.Windows.Forms.Button();
+            this.nmOutlineHollowAreasLineThickness = new System.Windows.Forms.NumericUpDown();
+            this.label3 = new System.Windows.Forms.Label();
+            this.cbLayerDifferenceDefault = new System.Windows.Forms.CheckBox();
+            this.label19 = new System.Windows.Forms.Label();
+            this.btnResinTrapColor = new System.Windows.Forms.Button();
+            this.btnResinTrapHLColor = new System.Windows.Forms.Button();
+            this.btnOutlineHollowAreasColor = new System.Windows.Forms.Button();
+            this.btnNextLayerColor = new System.Windows.Forms.Button();
+            this.btnOutlinePrintVolumeBoundsColor = new System.Windows.Forms.Button();
+            this.cbOutlineLayerBounds = new System.Windows.Forms.CheckBox();
+            this.label6 = new System.Windows.Forms.Label();
+            this.label14 = new System.Windows.Forms.Label();
+            this.label16 = new System.Windows.Forms.Label();
+            this.label4 = new System.Windows.Forms.Label();
+            this.nmOutlineLayerBoundsLineThickness = new System.Windows.Forms.NumericUpDown();
+            this.label5 = new System.Windows.Forms.Label();
+            this.label15 = new System.Windows.Forms.Label();
+            this.label17 = new System.Windows.Forms.Label();
+            this.btnTouchingBoundsColor = new System.Windows.Forms.Button();
+            this.cbOutlinePrintVolumeBounds = new System.Windows.Forms.CheckBox();
+            this.btnOutlineLayerBoundsColor = new System.Windows.Forms.Button();
             this.label37 = new System.Windows.Forms.Label();
-            this.label36 = new System.Windows.Forms.Label();
-            this.cbCrosshairShowOnlyOnSelectedIssues = new System.Windows.Forms.CheckBox();
-            this.label38 = new System.Windows.Forms.Label();
-            this.nmCrosshairLineLength = new System.Windows.Forms.NumericUpDown();
-            this.cbCrosshairFadeLevel = new System.Windows.Forms.ComboBox();
+            this.nmOutlinePrintVolumeBoundsLineThickness = new System.Windows.Forms.NumericUpDown();
+            this.btnCrosshairColor = new System.Windows.Forms.Button();
+            this.groupBox7 = new System.Windows.Forms.GroupBox();
+            this.label43 = new System.Windows.Forms.Label();
+            this.cbZoomToFit = new System.Windows.Forms.ComboBox();
             this.cbZoomIssues = new System.Windows.Forms.CheckBox();
+            this.cbZoomIssuesAuto = new System.Windows.Forms.CheckBox();
+            this.label38 = new System.Windows.Forms.Label();
             this.cbZoomLockLevel = new System.Windows.Forms.ComboBox();
+            this.groupBox8 = new System.Windows.Forms.GroupBox();
+            this.label44 = new System.Windows.Forms.Label();
+            this.cbCrosshairShowOnlyOnSelectedIssues = new System.Windows.Forms.CheckBox();
+            this.cbCrosshairFadeLevel = new System.Windows.Forms.ComboBox();
+            this.nmCrosshairLineLength = new System.Windows.Forms.NumericUpDown();
+            this.label40 = new System.Windows.Forms.Label();
+            this.label36 = new System.Windows.Forms.Label();
+            this.label41 = new System.Windows.Forms.Label();
+            this.label39 = new System.Windows.Forms.Label();
+            this.nmCrosshairLineMargin = new System.Windows.Forms.NumericUpDown();
+            this.groupBox9 = new System.Windows.Forms.GroupBox();
+            this.cbLayerAutoRotateBestView = new System.Windows.Forms.CheckBox();
+            this.cbLayerZoomToFit = new System.Windows.Forms.CheckBox();
             this.tabPage3 = new System.Windows.Forms.TabPage();
             this.tabPage4 = new System.Windows.Forms.TabPage();
-            this.cbPartialUpdateIslandsOnEditing = new System.Windows.Forms.CheckBox();
+            this.groupBox10 = new System.Windows.Forms.GroupBox();
             this.btnPixelEditorDrainHoleColor = new System.Windows.Forms.Button();
             this.btnPixelEditorDrainHoleHLColor = new System.Windows.Forms.Button();
             this.label26 = new System.Windows.Forms.Label();
@@ -153,6 +161,7 @@
             this.label23 = new System.Windows.Forms.Label();
             this.btnPixelEditorAddPixelColor = new System.Windows.Forms.Button();
             this.btnPixelEditorAddPixelHLColor = new System.Windows.Forms.Button();
+            this.cbPartialUpdateIslandsOnEditing = new System.Windows.Forms.CheckBox();
             this.tabPage5 = new System.Windows.Forms.TabPage();
             this.nmLayerRepairRemoveIslandsBelowEqualPixelsDefault = new System.Windows.Forms.NumericUpDown();
             this.label35 = new System.Windows.Forms.Label();
@@ -165,10 +174,6 @@
             this.cbLayerRepairLayersIslands = new System.Windows.Forms.CheckBox();
             this.panel1 = new System.Windows.Forms.Panel();
             this.toolTip = new System.Windows.Forms.ToolTip(this.components);
-            this.cbComputeEmptyLayers = new System.Windows.Forms.CheckBox();
-            ((System.ComponentModel.ISupportInitialize)(this.nmOutlineHollowAreasLineThickness)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nmOutlineLayerBoundsLineThickness)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nmOutlinePrintVolumeBoundsLineThickness)).BeginInit();
             this.groupBox3.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nmResinTrapBinaryThreshold)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nmResinTrapMaximumPixelBrightnessToDrain)).BeginInit();
@@ -183,13 +188,21 @@
             this.groupBox1.SuspendLayout();
             this.tabSettings.SuspendLayout();
             this.tabPage1.SuspendLayout();
-            this.groupBox5.SuspendLayout();
             this.groupBox4.SuspendLayout();
+            this.groupBox5.SuspendLayout();
             this.tabPage2.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nmCrosshairLineMargin)).BeginInit();
+            this.groupBox6.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.nmOutlineHollowAreasLineThickness)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nmOutlineLayerBoundsLineThickness)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nmOutlinePrintVolumeBoundsLineThickness)).BeginInit();
+            this.groupBox7.SuspendLayout();
+            this.groupBox8.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nmCrosshairLineLength)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nmCrosshairLineMargin)).BeginInit();
+            this.groupBox9.SuspendLayout();
             this.tabPage3.SuspendLayout();
             this.tabPage4.SuspendLayout();
+            this.groupBox10.SuspendLayout();
             this.tabPage5.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nmLayerRepairRemoveIslandsBelowEqualPixelsDefault)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nmLayerRepairDefaultOpeningIterations)).BeginInit();
@@ -197,190 +210,10 @@
             this.panel1.SuspendLayout();
             this.SuspendLayout();
             // 
-            // label1
-            // 
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(9, 15);
-            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(202, 18);
-            this.label1.TabIndex = 0;
-            this.label1.Text = "Previous and next layer color:";
-            // 
-            // btnPreviousNextLayerColor
-            // 
-            this.btnPreviousNextLayerColor.BackColor = System.Drawing.Color.White;
-            this.btnPreviousNextLayerColor.FlatAppearance.BorderColor = System.Drawing.Color.Black;
-            this.btnPreviousNextLayerColor.FlatAppearance.BorderSize = 2;
-            this.btnPreviousNextLayerColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnPreviousNextLayerColor.Location = new System.Drawing.Point(219, 8);
-            this.btnPreviousNextLayerColor.Margin = new System.Windows.Forms.Padding(4);
-            this.btnPreviousNextLayerColor.Name = "btnPreviousNextLayerColor";
-            this.btnPreviousNextLayerColor.Size = new System.Drawing.Size(32, 32);
-            this.btnPreviousNextLayerColor.TabIndex = 1;
-            this.btnPreviousNextLayerColor.UseVisualStyleBackColor = false;
-            this.btnPreviousNextLayerColor.Click += new System.EventHandler(this.EventClick);
-            // 
             // colorDialog
             // 
             this.colorDialog.AnyColor = true;
             this.colorDialog.FullOpen = true;
-            // 
-            // btnPreviousLayerColor
-            // 
-            this.btnPreviousLayerColor.BackColor = System.Drawing.Color.White;
-            this.btnPreviousLayerColor.FlatAppearance.BorderColor = System.Drawing.Color.Black;
-            this.btnPreviousLayerColor.FlatAppearance.BorderSize = 2;
-            this.btnPreviousLayerColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnPreviousLayerColor.Location = new System.Drawing.Point(219, 48);
-            this.btnPreviousLayerColor.Margin = new System.Windows.Forms.Padding(4);
-            this.btnPreviousLayerColor.Name = "btnPreviousLayerColor";
-            this.btnPreviousLayerColor.Size = new System.Drawing.Size(32, 32);
-            this.btnPreviousLayerColor.TabIndex = 3;
-            this.btnPreviousLayerColor.UseVisualStyleBackColor = false;
-            this.btnPreviousLayerColor.Click += new System.EventHandler(this.EventClick);
-            // 
-            // label2
-            // 
-            this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(9, 55);
-            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(143, 18);
-            this.label2.TabIndex = 2;
-            this.label2.Text = "Previous layer color:";
-            // 
-            // btnNextLayerColor
-            // 
-            this.btnNextLayerColor.BackColor = System.Drawing.Color.White;
-            this.btnNextLayerColor.FlatAppearance.BorderColor = System.Drawing.Color.Black;
-            this.btnNextLayerColor.FlatAppearance.BorderSize = 2;
-            this.btnNextLayerColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnNextLayerColor.Location = new System.Drawing.Point(219, 88);
-            this.btnNextLayerColor.Margin = new System.Windows.Forms.Padding(4);
-            this.btnNextLayerColor.Name = "btnNextLayerColor";
-            this.btnNextLayerColor.Size = new System.Drawing.Size(32, 32);
-            this.btnNextLayerColor.TabIndex = 5;
-            this.btnNextLayerColor.UseVisualStyleBackColor = false;
-            this.btnNextLayerColor.Click += new System.EventHandler(this.EventClick);
-            // 
-            // label3
-            // 
-            this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(9, 95);
-            this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(115, 18);
-            this.label3.TabIndex = 4;
-            this.label3.Text = "Next layer color:";
-            // 
-            // btnTouchingBoundsColor
-            // 
-            this.btnTouchingBoundsColor.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnTouchingBoundsColor.BackColor = System.Drawing.Color.White;
-            this.btnTouchingBoundsColor.FlatAppearance.BorderColor = System.Drawing.Color.Black;
-            this.btnTouchingBoundsColor.FlatAppearance.BorderSize = 2;
-            this.btnTouchingBoundsColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnTouchingBoundsColor.Location = new System.Drawing.Point(536, 88);
-            this.btnTouchingBoundsColor.Margin = new System.Windows.Forms.Padding(4);
-            this.btnTouchingBoundsColor.Name = "btnTouchingBoundsColor";
-            this.btnTouchingBoundsColor.Size = new System.Drawing.Size(32, 32);
-            this.btnTouchingBoundsColor.TabIndex = 7;
-            this.btnTouchingBoundsColor.UseVisualStyleBackColor = false;
-            this.btnTouchingBoundsColor.Click += new System.EventHandler(this.EventClick);
-            // 
-            // label4
-            // 
-            this.label4.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(332, 15);
-            this.label4.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(194, 18);
-            this.label4.TabIndex = 6;
-            this.label4.Text = "Island color / Highlight color:";
-            // 
-            // label5
-            // 
-            this.label5.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(304, 55);
-            this.label5.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(223, 18);
-            this.label5.TabIndex = 8;
-            this.label5.Text = "Resin trap color / Highlight color:";
-            // 
-            // label6
-            // 
-            this.label6.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.label6.AutoSize = true;
-            this.label6.Location = new System.Drawing.Point(372, 95);
-            this.label6.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(156, 18);
-            this.label6.TabIndex = 9;
-            this.label6.Text = "Touching bound color:";
-            // 
-            // btnResinTrapColor
-            // 
-            this.btnResinTrapColor.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnResinTrapColor.BackColor = System.Drawing.Color.White;
-            this.btnResinTrapColor.FlatAppearance.BorderColor = System.Drawing.Color.Black;
-            this.btnResinTrapColor.FlatAppearance.BorderSize = 2;
-            this.btnResinTrapColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnResinTrapColor.Location = new System.Drawing.Point(536, 48);
-            this.btnResinTrapColor.Margin = new System.Windows.Forms.Padding(4);
-            this.btnResinTrapColor.Name = "btnResinTrapColor";
-            this.btnResinTrapColor.Size = new System.Drawing.Size(32, 32);
-            this.btnResinTrapColor.TabIndex = 10;
-            this.btnResinTrapColor.UseVisualStyleBackColor = false;
-            this.btnResinTrapColor.Click += new System.EventHandler(this.EventClick);
-            // 
-            // btnResinTrapHLColor
-            // 
-            this.btnResinTrapHLColor.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnResinTrapHLColor.BackColor = System.Drawing.Color.White;
-            this.btnResinTrapHLColor.FlatAppearance.BorderColor = System.Drawing.Color.Black;
-            this.btnResinTrapHLColor.FlatAppearance.BorderSize = 2;
-            this.btnResinTrapHLColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnResinTrapHLColor.Location = new System.Drawing.Point(576, 48);
-            this.btnResinTrapHLColor.Margin = new System.Windows.Forms.Padding(4);
-            this.btnResinTrapHLColor.Name = "btnResinTrapHLColor";
-            this.btnResinTrapHLColor.Size = new System.Drawing.Size(32, 32);
-            this.btnResinTrapHLColor.TabIndex = 10;
-            this.btnResinTrapHLColor.UseVisualStyleBackColor = false;
-            this.btnResinTrapHLColor.Click += new System.EventHandler(this.EventClick);
-            // 
-            // btnIslandColor
-            // 
-            this.btnIslandColor.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnIslandColor.BackColor = System.Drawing.Color.White;
-            this.btnIslandColor.FlatAppearance.BorderColor = System.Drawing.Color.Black;
-            this.btnIslandColor.FlatAppearance.BorderSize = 2;
-            this.btnIslandColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnIslandColor.Location = new System.Drawing.Point(536, 8);
-            this.btnIslandColor.Margin = new System.Windows.Forms.Padding(4);
-            this.btnIslandColor.Name = "btnIslandColor";
-            this.btnIslandColor.Size = new System.Drawing.Size(32, 32);
-            this.btnIslandColor.TabIndex = 11;
-            this.btnIslandColor.UseVisualStyleBackColor = false;
-            this.btnIslandColor.Click += new System.EventHandler(this.EventClick);
-            // 
-            // btnIslandHLColor
-            // 
-            this.btnIslandHLColor.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnIslandHLColor.BackColor = System.Drawing.Color.White;
-            this.btnIslandHLColor.FlatAppearance.BorderColor = System.Drawing.Color.Black;
-            this.btnIslandHLColor.FlatAppearance.BorderSize = 2;
-            this.btnIslandHLColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnIslandHLColor.Location = new System.Drawing.Point(576, 8);
-            this.btnIslandHLColor.Margin = new System.Windows.Forms.Padding(4);
-            this.btnIslandHLColor.Name = "btnIslandHLColor";
-            this.btnIslandHLColor.Size = new System.Drawing.Size(32, 32);
-            this.btnIslandHLColor.TabIndex = 11;
-            this.btnIslandHLColor.UseVisualStyleBackColor = false;
-            this.btnIslandHLColor.Click += new System.EventHandler(this.EventClick);
             // 
             // btnSave
             // 
@@ -391,7 +224,7 @@
             this.btnSave.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.btnSave.Name = "btnSave";
             this.btnSave.Size = new System.Drawing.Size(150, 48);
-            this.btnSave.TabIndex = 12;
+            this.btnSave.TabIndex = 1;
             this.btnSave.Text = "&Save";
             this.btnSave.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             this.btnSave.UseVisualStyleBackColor = true;
@@ -407,7 +240,7 @@
             this.btnCancel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(150, 48);
-            this.btnCancel.TabIndex = 13;
+            this.btnCancel.TabIndex = 2;
             this.btnCancel.Text = "&Cancel";
             this.btnCancel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             this.btnCancel.UseVisualStyleBackColor = true;
@@ -417,9 +250,9 @@
             this.cbCheckForUpdatesOnStartup.AutoSize = true;
             this.cbCheckForUpdatesOnStartup.Location = new System.Drawing.Point(6, 51);
             this.cbCheckForUpdatesOnStartup.Name = "cbCheckForUpdatesOnStartup";
-            this.cbCheckForUpdatesOnStartup.Size = new System.Drawing.Size(218, 22);
+            this.cbCheckForUpdatesOnStartup.Size = new System.Drawing.Size(223, 22);
             this.cbCheckForUpdatesOnStartup.TabIndex = 7;
-            this.cbCheckForUpdatesOnStartup.Text = "Check for updates on startup";
+            this.cbCheckForUpdatesOnStartup.Text = "Check for Updates on Startup";
             this.cbCheckForUpdatesOnStartup.UseVisualStyleBackColor = true;
             // 
             // cbStartMaximized
@@ -429,246 +262,8 @@
             this.cbStartMaximized.Name = "cbStartMaximized";
             this.cbStartMaximized.Size = new System.Drawing.Size(133, 22);
             this.cbStartMaximized.TabIndex = 6;
-            this.cbStartMaximized.Text = "Start maximized";
+            this.cbStartMaximized.Text = "Start Maximized";
             this.cbStartMaximized.UseVisualStyleBackColor = true;
-            // 
-            // cbZoomToFitPrintVolumeBounds
-            // 
-            this.cbZoomToFitPrintVolumeBounds.AutoSize = true;
-            this.cbZoomToFitPrintVolumeBounds.Location = new System.Drawing.Point(336, 277);
-            this.cbZoomToFitPrintVolumeBounds.Name = "cbZoomToFitPrintVolumeBounds";
-            this.cbZoomToFitPrintVolumeBounds.Size = new System.Drawing.Size(272, 22);
-            this.cbZoomToFitPrintVolumeBounds.TabIndex = 34;
-            this.cbZoomToFitPrintVolumeBounds.Text = "Zoom to print volume bounds instead";
-            this.cbZoomToFitPrintVolumeBounds.UseVisualStyleBackColor = true;
-            // 
-            // cbOutlineHollowAreas
-            // 
-            this.cbOutlineHollowAreas.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.cbOutlineHollowAreas.AutoSize = true;
-            this.cbOutlineHollowAreas.Location = new System.Drawing.Point(477, 213);
-            this.cbOutlineHollowAreas.Name = "cbOutlineHollowAreas";
-            this.cbOutlineHollowAreas.Size = new System.Drawing.Size(131, 22);
-            this.cbOutlineHollowAreas.TabIndex = 33;
-            this.cbOutlineHollowAreas.Text = "Show by default";
-            this.cbOutlineHollowAreas.UseVisualStyleBackColor = true;
-            // 
-            // label18
-            // 
-            this.label18.AutoSize = true;
-            this.label18.Location = new System.Drawing.Point(321, 215);
-            this.label18.Name = "label18";
-            this.label18.Size = new System.Drawing.Size(150, 18);
-            this.label18.TabIndex = 32;
-            this.label18.Text = "Line thickness (-1-50)";
-            // 
-            // nmOutlineHollowAreasLineThickness
-            // 
-            this.nmOutlineHollowAreasLineThickness.Location = new System.Drawing.Point(258, 212);
-            this.nmOutlineHollowAreasLineThickness.Maximum = new decimal(new int[] {
-            50,
-            0,
-            0,
-            0});
-            this.nmOutlineHollowAreasLineThickness.Minimum = new decimal(new int[] {
-            1,
-            0,
-            0,
-            -2147483648});
-            this.nmOutlineHollowAreasLineThickness.Name = "nmOutlineHollowAreasLineThickness";
-            this.nmOutlineHollowAreasLineThickness.Size = new System.Drawing.Size(57, 24);
-            this.nmOutlineHollowAreasLineThickness.TabIndex = 31;
-            this.nmOutlineHollowAreasLineThickness.Value = new decimal(new int[] {
-            2,
-            0,
-            0,
-            0});
-            // 
-            // label19
-            // 
-            this.label19.AutoSize = true;
-            this.label19.Location = new System.Drawing.Point(9, 215);
-            this.label19.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label19.Name = "label19";
-            this.label19.Size = new System.Drawing.Size(187, 18);
-            this.label19.TabIndex = 29;
-            this.label19.Text = "Outline Hollow areas color:";
-            // 
-            // btnOutlineHollowAreasColor
-            // 
-            this.btnOutlineHollowAreasColor.BackColor = System.Drawing.Color.White;
-            this.btnOutlineHollowAreasColor.FlatAppearance.BorderColor = System.Drawing.Color.Black;
-            this.btnOutlineHollowAreasColor.FlatAppearance.BorderSize = 2;
-            this.btnOutlineHollowAreasColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnOutlineHollowAreasColor.Location = new System.Drawing.Point(219, 208);
-            this.btnOutlineHollowAreasColor.Margin = new System.Windows.Forms.Padding(4);
-            this.btnOutlineHollowAreasColor.Name = "btnOutlineHollowAreasColor";
-            this.btnOutlineHollowAreasColor.Size = new System.Drawing.Size(32, 32);
-            this.btnOutlineHollowAreasColor.TabIndex = 30;
-            this.btnOutlineHollowAreasColor.UseVisualStyleBackColor = false;
-            this.btnOutlineHollowAreasColor.Click += new System.EventHandler(this.EventClick);
-            // 
-            // cbOutlineLayerBounds
-            // 
-            this.cbOutlineLayerBounds.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.cbOutlineLayerBounds.AutoSize = true;
-            this.cbOutlineLayerBounds.Location = new System.Drawing.Point(477, 173);
-            this.cbOutlineLayerBounds.Name = "cbOutlineLayerBounds";
-            this.cbOutlineLayerBounds.Size = new System.Drawing.Size(131, 22);
-            this.cbOutlineLayerBounds.TabIndex = 28;
-            this.cbOutlineLayerBounds.Text = "Show by default";
-            this.cbOutlineLayerBounds.UseVisualStyleBackColor = true;
-            // 
-            // label16
-            // 
-            this.label16.AutoSize = true;
-            this.label16.Location = new System.Drawing.Point(321, 175);
-            this.label16.Name = "label16";
-            this.label16.Size = new System.Drawing.Size(145, 18);
-            this.label16.TabIndex = 27;
-            this.label16.Text = "Line thickness (1-50)";
-            // 
-            // nmOutlineLayerBoundsLineThickness
-            // 
-            this.nmOutlineLayerBoundsLineThickness.Location = new System.Drawing.Point(258, 172);
-            this.nmOutlineLayerBoundsLineThickness.Maximum = new decimal(new int[] {
-            50,
-            0,
-            0,
-            0});
-            this.nmOutlineLayerBoundsLineThickness.Minimum = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-            this.nmOutlineLayerBoundsLineThickness.Name = "nmOutlineLayerBoundsLineThickness";
-            this.nmOutlineLayerBoundsLineThickness.Size = new System.Drawing.Size(57, 24);
-            this.nmOutlineLayerBoundsLineThickness.TabIndex = 26;
-            this.nmOutlineLayerBoundsLineThickness.Value = new decimal(new int[] {
-            2,
-            0,
-            0,
-            0});
-            // 
-            // label17
-            // 
-            this.label17.AutoSize = true;
-            this.label17.Location = new System.Drawing.Point(9, 175);
-            this.label17.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label17.Name = "label17";
-            this.label17.Size = new System.Drawing.Size(189, 18);
-            this.label17.TabIndex = 24;
-            this.label17.Text = "Outline Layer bounds color:";
-            // 
-            // btnOutlineLayerBoundsColor
-            // 
-            this.btnOutlineLayerBoundsColor.BackColor = System.Drawing.Color.White;
-            this.btnOutlineLayerBoundsColor.FlatAppearance.BorderColor = System.Drawing.Color.Black;
-            this.btnOutlineLayerBoundsColor.FlatAppearance.BorderSize = 2;
-            this.btnOutlineLayerBoundsColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnOutlineLayerBoundsColor.Location = new System.Drawing.Point(219, 168);
-            this.btnOutlineLayerBoundsColor.Margin = new System.Windows.Forms.Padding(4);
-            this.btnOutlineLayerBoundsColor.Name = "btnOutlineLayerBoundsColor";
-            this.btnOutlineLayerBoundsColor.Size = new System.Drawing.Size(32, 32);
-            this.btnOutlineLayerBoundsColor.TabIndex = 25;
-            this.btnOutlineLayerBoundsColor.UseVisualStyleBackColor = false;
-            this.btnOutlineLayerBoundsColor.Click += new System.EventHandler(this.EventClick);
-            // 
-            // cbOutlinePrintVolumeBounds
-            // 
-            this.cbOutlinePrintVolumeBounds.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.cbOutlinePrintVolumeBounds.AutoSize = true;
-            this.cbOutlinePrintVolumeBounds.Location = new System.Drawing.Point(477, 133);
-            this.cbOutlinePrintVolumeBounds.Name = "cbOutlinePrintVolumeBounds";
-            this.cbOutlinePrintVolumeBounds.Size = new System.Drawing.Size(131, 22);
-            this.cbOutlinePrintVolumeBounds.TabIndex = 23;
-            this.cbOutlinePrintVolumeBounds.Text = "Show by default";
-            this.cbOutlinePrintVolumeBounds.UseVisualStyleBackColor = true;
-            // 
-            // label15
-            // 
-            this.label15.AutoSize = true;
-            this.label15.Location = new System.Drawing.Point(321, 135);
-            this.label15.Name = "label15";
-            this.label15.Size = new System.Drawing.Size(145, 18);
-            this.label15.TabIndex = 22;
-            this.label15.Text = "Line thickness (1-50)";
-            // 
-            // nmOutlinePrintVolumeBoundsLineThickness
-            // 
-            this.nmOutlinePrintVolumeBoundsLineThickness.Location = new System.Drawing.Point(258, 132);
-            this.nmOutlinePrintVolumeBoundsLineThickness.Maximum = new decimal(new int[] {
-            50,
-            0,
-            0,
-            0});
-            this.nmOutlinePrintVolumeBoundsLineThickness.Minimum = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-            this.nmOutlinePrintVolumeBoundsLineThickness.Name = "nmOutlinePrintVolumeBoundsLineThickness";
-            this.nmOutlinePrintVolumeBoundsLineThickness.Size = new System.Drawing.Size(57, 24);
-            this.nmOutlinePrintVolumeBoundsLineThickness.TabIndex = 19;
-            this.nmOutlinePrintVolumeBoundsLineThickness.Value = new decimal(new int[] {
-            2,
-            0,
-            0,
-            0});
-            // 
-            // label14
-            // 
-            this.label14.AutoSize = true;
-            this.label14.Location = new System.Drawing.Point(9, 135);
-            this.label14.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label14.Name = "label14";
-            this.label14.Size = new System.Drawing.Size(185, 18);
-            this.label14.TabIndex = 16;
-            this.label14.Text = "Print volume bounds color:";
-            // 
-            // btnOutlinePrintVolumeBoundsColor
-            // 
-            this.btnOutlinePrintVolumeBoundsColor.BackColor = System.Drawing.Color.White;
-            this.btnOutlinePrintVolumeBoundsColor.FlatAppearance.BorderColor = System.Drawing.Color.Black;
-            this.btnOutlinePrintVolumeBoundsColor.FlatAppearance.BorderSize = 2;
-            this.btnOutlinePrintVolumeBoundsColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnOutlinePrintVolumeBoundsColor.Location = new System.Drawing.Point(219, 128);
-            this.btnOutlinePrintVolumeBoundsColor.Margin = new System.Windows.Forms.Padding(4);
-            this.btnOutlinePrintVolumeBoundsColor.Name = "btnOutlinePrintVolumeBoundsColor";
-            this.btnOutlinePrintVolumeBoundsColor.Size = new System.Drawing.Size(32, 32);
-            this.btnOutlinePrintVolumeBoundsColor.TabIndex = 17;
-            this.btnOutlinePrintVolumeBoundsColor.UseVisualStyleBackColor = false;
-            this.btnOutlinePrintVolumeBoundsColor.Click += new System.EventHandler(this.EventClick);
-            // 
-            // cbLayerZoomToFit
-            // 
-            this.cbLayerZoomToFit.AutoSize = true;
-            this.cbLayerZoomToFit.Location = new System.Drawing.Point(11, 277);
-            this.cbLayerZoomToFit.Name = "cbLayerZoomToFit";
-            this.cbLayerZoomToFit.Size = new System.Drawing.Size(313, 22);
-            this.cbLayerZoomToFit.TabIndex = 15;
-            this.cbLayerZoomToFit.Text = "Zoom to fit layer on load and window resize";
-            this.cbLayerZoomToFit.UseVisualStyleBackColor = true;
-            // 
-            // cbLayerDifferenceDefault
-            // 
-            this.cbLayerDifferenceDefault.AutoSize = true;
-            this.cbLayerDifferenceDefault.Location = new System.Drawing.Point(11, 333);
-            this.cbLayerDifferenceDefault.Name = "cbLayerDifferenceDefault";
-            this.cbLayerDifferenceDefault.Size = new System.Drawing.Size(234, 22);
-            this.cbLayerDifferenceDefault.TabIndex = 13;
-            this.cbLayerDifferenceDefault.Text = "Show layer difference by default";
-            this.cbLayerDifferenceDefault.UseVisualStyleBackColor = true;
-            // 
-            // cbLayerAutoRotateBestView
-            // 
-            this.cbLayerAutoRotateBestView.AutoSize = true;
-            this.cbLayerAutoRotateBestView.Location = new System.Drawing.Point(11, 249);
-            this.cbLayerAutoRotateBestView.Name = "cbLayerAutoRotateBestView";
-            this.cbLayerAutoRotateBestView.Size = new System.Drawing.Size(327, 22);
-            this.cbLayerAutoRotateBestView.TabIndex = 12;
-            this.cbLayerAutoRotateBestView.Text = "Auto rotate layer to best fit window on file load";
-            this.cbLayerAutoRotateBestView.UseVisualStyleBackColor = true;
             // 
             // cbComputeIssuesOnLoad
             // 
@@ -689,7 +284,7 @@
             this.btnReset.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.btnReset.Name = "btnReset";
             this.btnReset.Size = new System.Drawing.Size(158, 48);
-            this.btnReset.TabIndex = 16;
+            this.btnReset.TabIndex = 0;
             this.btnReset.Text = "&Reset all settings";
             this.btnReset.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             this.btnReset.UseVisualStyleBackColor = true;
@@ -710,9 +305,9 @@
             this.cbComputeResinTraps.AutoSize = true;
             this.cbComputeResinTraps.Location = new System.Drawing.Point(164, 79);
             this.cbComputeResinTraps.Name = "cbComputeResinTraps";
-            this.cbComputeResinTraps.Size = new System.Drawing.Size(102, 22);
+            this.cbComputeResinTraps.Size = new System.Drawing.Size(107, 22);
             this.cbComputeResinTraps.TabIndex = 17;
-            this.cbComputeResinTraps.Text = "Resin traps";
+            this.cbComputeResinTraps.Text = "Resin Traps";
             this.cbComputeResinTraps.UseVisualStyleBackColor = true;
             // 
             // groupBox3
@@ -726,9 +321,9 @@
             this.groupBox3.Controls.Add(this.nmResinTrapRequiredAreaToProcessCheck);
             this.groupBox3.Controls.Add(this.label11);
             this.groupBox3.Dock = System.Windows.Forms.DockStyle.Top;
-            this.groupBox3.Location = new System.Drawing.Point(3, 328);
+            this.groupBox3.Location = new System.Drawing.Point(3, 351);
             this.groupBox3.Name = "groupBox3";
-            this.groupBox3.Size = new System.Drawing.Size(610, 152);
+            this.groupBox3.Size = new System.Drawing.Size(610, 162);
             this.groupBox3.TabIndex = 24;
             this.groupBox3.TabStop = false;
             this.groupBox3.Text = "Resin Traps";
@@ -762,7 +357,7 @@
             // 
             // nmResinTrapMaximumPixelBrightnessToDrain
             // 
-            this.nmResinTrapMaximumPixelBrightnessToDrain.Location = new System.Drawing.Point(10, 113);
+            this.nmResinTrapMaximumPixelBrightnessToDrain.Location = new System.Drawing.Point(10, 125);
             this.nmResinTrapMaximumPixelBrightnessToDrain.Maximum = new decimal(new int[] {
             150,
             0,
@@ -780,7 +375,7 @@
             // label13
             // 
             this.label13.AutoSize = true;
-            this.label13.Location = new System.Drawing.Point(73, 116);
+            this.label13.Location = new System.Drawing.Point(73, 128);
             this.label13.Name = "label13";
             this.label13.Size = new System.Drawing.Size(347, 18);
             this.label13.TabIndex = 25;
@@ -788,7 +383,7 @@
             // 
             // nmResinTrapRequiredBlackPixelsToDrain
             // 
-            this.nmResinTrapRequiredBlackPixelsToDrain.Location = new System.Drawing.Point(10, 83);
+            this.nmResinTrapRequiredBlackPixelsToDrain.Location = new System.Drawing.Point(10, 91);
             this.nmResinTrapRequiredBlackPixelsToDrain.Maximum = new decimal(new int[] {
             255,
             0,
@@ -811,7 +406,7 @@
             // label12
             // 
             this.label12.AutoSize = true;
-            this.label12.Location = new System.Drawing.Point(73, 86);
+            this.label12.Location = new System.Drawing.Point(73, 94);
             this.label12.Name = "label12";
             this.label12.Size = new System.Drawing.Size(441, 18);
             this.label12.TabIndex = 23;
@@ -819,7 +414,7 @@
             // 
             // nmResinTrapRequiredAreaToProcessCheck
             // 
-            this.nmResinTrapRequiredAreaToProcessCheck.Location = new System.Drawing.Point(10, 53);
+            this.nmResinTrapRequiredAreaToProcessCheck.Location = new System.Drawing.Point(10, 57);
             this.nmResinTrapRequiredAreaToProcessCheck.Maximum = new decimal(new int[] {
             255,
             0,
@@ -842,7 +437,7 @@
             // label11
             // 
             this.label11.AutoSize = true;
-            this.label11.Location = new System.Drawing.Point(73, 56);
+            this.label11.Location = new System.Drawing.Point(73, 60);
             this.label11.Name = "label11";
             this.label11.Size = new System.Drawing.Size(504, 18);
             this.label11.TabIndex = 21;
@@ -864,7 +459,7 @@
             this.groupBox2.Dock = System.Windows.Forms.DockStyle.Top;
             this.groupBox2.Location = new System.Drawing.Point(3, 114);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(610, 214);
+            this.groupBox2.Size = new System.Drawing.Size(610, 237);
             this.groupBox2.TabIndex = 23;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Islands";
@@ -874,15 +469,15 @@
             this.cbIslandAllowDiagonalBonds.AutoSize = true;
             this.cbIslandAllowDiagonalBonds.Location = new System.Drawing.Point(10, 23);
             this.cbIslandAllowDiagonalBonds.Name = "cbIslandAllowDiagonalBonds";
-            this.cbIslandAllowDiagonalBonds.Size = new System.Drawing.Size(166, 22);
+            this.cbIslandAllowDiagonalBonds.Size = new System.Drawing.Size(327, 22);
             this.cbIslandAllowDiagonalBonds.TabIndex = 30;
-            this.cbIslandAllowDiagonalBonds.Text = "Allow diagonal bonds";
+            this.cbIslandAllowDiagonalBonds.Text = "Allow Diagonal Bonds During Island Detection";
             this.toolTip.SetToolTip(this.cbIslandAllowDiagonalBonds, resources.GetString("cbIslandAllowDiagonalBonds.ToolTip"));
             this.cbIslandAllowDiagonalBonds.UseVisualStyleBackColor = true;
             // 
             // nmIslandBinaryThreshold
             // 
-            this.nmIslandBinaryThreshold.Location = new System.Drawing.Point(10, 51);
+            this.nmIslandBinaryThreshold.Location = new System.Drawing.Point(10, 55);
             this.nmIslandBinaryThreshold.Maximum = new decimal(new int[] {
             254,
             0,
@@ -895,7 +490,7 @@
             // label21
             // 
             this.label21.AutoSize = true;
-            this.label21.Location = new System.Drawing.Point(73, 54);
+            this.label21.Location = new System.Drawing.Point(73, 58);
             this.label21.Name = "label21";
             this.label21.Size = new System.Drawing.Size(512, 18);
             this.label21.TabIndex = 29;
@@ -905,7 +500,7 @@
             // label10
             // 
             this.label10.AutoSize = true;
-            this.label10.Location = new System.Drawing.Point(73, 174);
+            this.label10.Location = new System.Drawing.Point(73, 194);
             this.label10.Name = "label10";
             this.label10.Size = new System.Drawing.Size(507, 18);
             this.label10.TabIndex = 25;
@@ -913,7 +508,7 @@
             // 
             // nmIslandRequiredPixelBrightnessToSupport
             // 
-            this.nmIslandRequiredPixelBrightnessToSupport.Location = new System.Drawing.Point(10, 171);
+            this.nmIslandRequiredPixelBrightnessToSupport.Location = new System.Drawing.Point(10, 191);
             this.nmIslandRequiredPixelBrightnessToSupport.Maximum = new decimal(new int[] {
             255,
             0,
@@ -936,7 +531,7 @@
             // label9
             // 
             this.label9.AutoSize = true;
-            this.label9.Location = new System.Drawing.Point(73, 144);
+            this.label9.Location = new System.Drawing.Point(73, 160);
             this.label9.Name = "label9";
             this.label9.Size = new System.Drawing.Size(385, 18);
             this.label9.TabIndex = 23;
@@ -944,7 +539,7 @@
             // 
             // nmIslandRequiredPixelsToSupport
             // 
-            this.nmIslandRequiredPixelsToSupport.Location = new System.Drawing.Point(10, 141);
+            this.nmIslandRequiredPixelsToSupport.Location = new System.Drawing.Point(10, 157);
             this.nmIslandRequiredPixelsToSupport.Maximum = new decimal(new int[] {
             255,
             0,
@@ -966,7 +561,7 @@
             // 
             // nmIslandRequiredAreaToProcessCheck
             // 
-            this.nmIslandRequiredAreaToProcessCheck.Location = new System.Drawing.Point(10, 81);
+            this.nmIslandRequiredAreaToProcessCheck.Location = new System.Drawing.Point(10, 89);
             this.nmIslandRequiredAreaToProcessCheck.Maximum = new decimal(new int[] {
             255,
             0,
@@ -989,7 +584,7 @@
             // label7
             // 
             this.label7.AutoSize = true;
-            this.label7.Location = new System.Drawing.Point(73, 84);
+            this.label7.Location = new System.Drawing.Point(73, 92);
             this.label7.Name = "label7";
             this.label7.Size = new System.Drawing.Size(481, 18);
             this.label7.TabIndex = 19;
@@ -998,7 +593,7 @@
             // label8
             // 
             this.label8.AutoSize = true;
-            this.label8.Location = new System.Drawing.Point(73, 114);
+            this.label8.Location = new System.Drawing.Point(73, 126);
             this.label8.Name = "label8";
             this.label8.Size = new System.Drawing.Size(439, 18);
             this.label8.TabIndex = 21;
@@ -1006,7 +601,7 @@
             // 
             // nmIslandRequiredPixelBrightnessToProcessCheck
             // 
-            this.nmIslandRequiredPixelBrightnessToProcessCheck.Location = new System.Drawing.Point(10, 111);
+            this.nmIslandRequiredPixelBrightnessToProcessCheck.Location = new System.Drawing.Point(10, 123);
             this.nmIslandRequiredPixelBrightnessToProcessCheck.Maximum = new decimal(new int[] {
             255,
             0,
@@ -1041,7 +636,17 @@
             this.groupBox1.Size = new System.Drawing.Size(610, 111);
             this.groupBox1.TabIndex = 22;
             this.groupBox1.TabStop = false;
-            this.groupBox1.Text = "Commun";
+            this.groupBox1.Text = "Common";
+            // 
+            // cbComputeEmptyLayers
+            // 
+            this.cbComputeEmptyLayers.AutoSize = true;
+            this.cbComputeEmptyLayers.Location = new System.Drawing.Point(427, 79);
+            this.cbComputeEmptyLayers.Name = "cbComputeEmptyLayers";
+            this.cbComputeEmptyLayers.Size = new System.Drawing.Size(117, 22);
+            this.cbComputeEmptyLayers.TabIndex = 21;
+            this.cbComputeEmptyLayers.Text = "Empty Layers";
+            this.cbComputeEmptyLayers.UseVisualStyleBackColor = true;
             // 
             // label42
             // 
@@ -1057,9 +662,9 @@
             this.cbComputeTouchingBounds.AutoSize = true;
             this.cbComputeTouchingBounds.Location = new System.Drawing.Point(272, 79);
             this.cbComputeTouchingBounds.Name = "cbComputeTouchingBounds";
-            this.cbComputeTouchingBounds.Size = new System.Drawing.Size(141, 22);
+            this.cbComputeTouchingBounds.Size = new System.Drawing.Size(155, 22);
             this.cbComputeTouchingBounds.TabIndex = 19;
-            this.cbComputeTouchingBounds.Text = "Touching bounds";
+            this.cbComputeTouchingBounds.Text = "Touching Boundary";
             this.cbComputeTouchingBounds.UseVisualStyleBackColor = true;
             // 
             // cbAutoComputeIssuesClickOnTab
@@ -1083,20 +688,32 @@
             this.tabSettings.Location = new System.Drawing.Point(0, 0);
             this.tabSettings.Name = "tabSettings";
             this.tabSettings.SelectedIndex = 0;
-            this.tabSettings.Size = new System.Drawing.Size(624, 625);
-            this.tabSettings.TabIndex = 18;
+            this.tabSettings.Size = new System.Drawing.Size(624, 661);
+            this.tabSettings.TabIndex = 0;
             // 
             // tabPage1
             // 
-            this.tabPage1.Controls.Add(this.groupBox5);
             this.tabPage1.Controls.Add(this.groupBox4);
+            this.tabPage1.Controls.Add(this.groupBox5);
             this.tabPage1.Location = new System.Drawing.Point(4, 27);
             this.tabPage1.Name = "tabPage1";
             this.tabPage1.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage1.Size = new System.Drawing.Size(616, 594);
+            this.tabPage1.Size = new System.Drawing.Size(616, 630);
             this.tabPage1.TabIndex = 0;
             this.tabPage1.Text = "General";
             this.tabPage1.UseVisualStyleBackColor = true;
+            // 
+            // groupBox4
+            // 
+            this.groupBox4.Controls.Add(this.cbStartMaximized);
+            this.groupBox4.Controls.Add(this.cbCheckForUpdatesOnStartup);
+            this.groupBox4.Dock = System.Windows.Forms.DockStyle.Top;
+            this.groupBox4.Location = new System.Drawing.Point(3, 3);
+            this.groupBox4.Name = "groupBox4";
+            this.groupBox4.Size = new System.Drawing.Size(610, 100);
+            this.groupBox4.TabIndex = 15;
+            this.groupBox4.TabStop = false;
+            this.groupBox4.Text = "Startup";
             // 
             // groupBox5
             // 
@@ -1123,325 +740,910 @@
             this.groupBox5.Controls.Add(this.tbFileSaveNameSuffix);
             this.groupBox5.Controls.Add(this.label27);
             this.groupBox5.Controls.Add(this.tbFileSaveNamePreffix);
-            this.groupBox5.Dock = System.Windows.Forms.DockStyle.Top;
-            this.groupBox5.Location = new System.Drawing.Point(3, 86);
+            this.groupBox5.Location = new System.Drawing.Point(3, 111);
             this.groupBox5.Name = "groupBox5";
-            this.groupBox5.Size = new System.Drawing.Size(610, 250);
-            this.groupBox5.TabIndex = 16;
+            this.groupBox5.Size = new System.Drawing.Size(610, 278);
+            this.groupBox5.TabIndex = 54;
             this.groupBox5.TabStop = false;
-            this.groupBox5.Text = "File operations";
+            this.groupBox5.Text = "File Dialog Settings";
             // 
             // btnFileExtractDefaultDirectoryClear
             // 
             this.btnFileExtractDefaultDirectoryClear.Image = global::UVtools.GUI.Properties.Resources.delete_16x16;
-            this.btnFileExtractDefaultDirectoryClear.Location = new System.Drawing.Point(574, 115);
+            this.btnFileExtractDefaultDirectoryClear.Location = new System.Drawing.Point(571, 133);
             this.btnFileExtractDefaultDirectoryClear.Name = "btnFileExtractDefaultDirectoryClear";
             this.btnFileExtractDefaultDirectoryClear.Size = new System.Drawing.Size(30, 24);
-            this.btnFileExtractDefaultDirectoryClear.TabIndex = 30;
+            this.btnFileExtractDefaultDirectoryClear.TabIndex = 76;
             this.btnFileExtractDefaultDirectoryClear.UseVisualStyleBackColor = true;
             this.btnFileExtractDefaultDirectoryClear.Click += new System.EventHandler(this.EventClick);
             // 
             // btnFileExtractDefaultDirectorySearch
             // 
             this.btnFileExtractDefaultDirectorySearch.Image = global::UVtools.GUI.Properties.Resources.Open_16x16;
-            this.btnFileExtractDefaultDirectorySearch.Location = new System.Drawing.Point(538, 115);
+            this.btnFileExtractDefaultDirectorySearch.Location = new System.Drawing.Point(535, 133);
             this.btnFileExtractDefaultDirectorySearch.Name = "btnFileExtractDefaultDirectorySearch";
             this.btnFileExtractDefaultDirectorySearch.Size = new System.Drawing.Size(30, 24);
-            this.btnFileExtractDefaultDirectorySearch.TabIndex = 29;
+            this.btnFileExtractDefaultDirectorySearch.TabIndex = 75;
             this.btnFileExtractDefaultDirectorySearch.UseVisualStyleBackColor = true;
             this.btnFileExtractDefaultDirectorySearch.Click += new System.EventHandler(this.EventClick);
             // 
             // label32
             // 
             this.label32.AutoSize = true;
-            this.label32.Location = new System.Drawing.Point(6, 118);
+            this.label32.Location = new System.Drawing.Point(3, 136);
             this.label32.Name = "label32";
-            this.label32.Size = new System.Drawing.Size(191, 18);
-            this.label32.TabIndex = 28;
-            this.label32.Text = "File extract default directory:";
+            this.label32.Size = new System.Drawing.Size(199, 18);
+            this.label32.TabIndex = 74;
+            this.label32.Text = "File Extract Default Directory:";
             // 
             // tbFileExtractDefaultDirectory
             // 
-            this.tbFileExtractDefaultDirectory.Location = new System.Drawing.Point(225, 115);
+            this.tbFileExtractDefaultDirectory.Location = new System.Drawing.Point(222, 133);
             this.tbFileExtractDefaultDirectory.Name = "tbFileExtractDefaultDirectory";
             this.tbFileExtractDefaultDirectory.ReadOnly = true;
             this.tbFileExtractDefaultDirectory.Size = new System.Drawing.Size(307, 24);
-            this.tbFileExtractDefaultDirectory.TabIndex = 27;
+            this.tbFileExtractDefaultDirectory.TabIndex = 73;
             // 
             // btnFileConvertDefaultDirectoryClear
             // 
             this.btnFileConvertDefaultDirectoryClear.Image = global::UVtools.GUI.Properties.Resources.delete_16x16;
-            this.btnFileConvertDefaultDirectoryClear.Location = new System.Drawing.Point(574, 145);
+            this.btnFileConvertDefaultDirectoryClear.Location = new System.Drawing.Point(571, 167);
             this.btnFileConvertDefaultDirectoryClear.Name = "btnFileConvertDefaultDirectoryClear";
             this.btnFileConvertDefaultDirectoryClear.Size = new System.Drawing.Size(30, 24);
-            this.btnFileConvertDefaultDirectoryClear.TabIndex = 26;
+            this.btnFileConvertDefaultDirectoryClear.TabIndex = 72;
             this.btnFileConvertDefaultDirectoryClear.UseVisualStyleBackColor = true;
             this.btnFileConvertDefaultDirectoryClear.Click += new System.EventHandler(this.EventClick);
             // 
             // btnFileConvertDefaultDirectorySearch
             // 
             this.btnFileConvertDefaultDirectorySearch.Image = global::UVtools.GUI.Properties.Resources.Open_16x16;
-            this.btnFileConvertDefaultDirectorySearch.Location = new System.Drawing.Point(538, 145);
+            this.btnFileConvertDefaultDirectorySearch.Location = new System.Drawing.Point(535, 167);
             this.btnFileConvertDefaultDirectorySearch.Name = "btnFileConvertDefaultDirectorySearch";
             this.btnFileConvertDefaultDirectorySearch.Size = new System.Drawing.Size(30, 24);
-            this.btnFileConvertDefaultDirectorySearch.TabIndex = 25;
+            this.btnFileConvertDefaultDirectorySearch.TabIndex = 71;
             this.btnFileConvertDefaultDirectorySearch.UseVisualStyleBackColor = true;
             this.btnFileConvertDefaultDirectorySearch.Click += new System.EventHandler(this.EventClick);
             // 
             // label31
             // 
             this.label31.AutoSize = true;
-            this.label31.Location = new System.Drawing.Point(6, 148);
+            this.label31.Location = new System.Drawing.Point(3, 170);
             this.label31.Name = "label31";
-            this.label31.Size = new System.Drawing.Size(196, 18);
-            this.label31.TabIndex = 24;
-            this.label31.Text = "File convert default directory:";
+            this.label31.Size = new System.Drawing.Size(205, 18);
+            this.label31.TabIndex = 70;
+            this.label31.Text = "File Convert Default Directory:";
             // 
             // tbFileConvertDefaultDirectory
             // 
-            this.tbFileConvertDefaultDirectory.Location = new System.Drawing.Point(225, 145);
+            this.tbFileConvertDefaultDirectory.Location = new System.Drawing.Point(222, 167);
             this.tbFileConvertDefaultDirectory.Name = "tbFileConvertDefaultDirectory";
             this.tbFileConvertDefaultDirectory.ReadOnly = true;
             this.tbFileConvertDefaultDirectory.Size = new System.Drawing.Size(307, 24);
-            this.tbFileConvertDefaultDirectory.TabIndex = 23;
+            this.tbFileConvertDefaultDirectory.TabIndex = 69;
             // 
             // btnFileSaveDefaultDirectoryClear
             // 
             this.btnFileSaveDefaultDirectoryClear.Image = global::UVtools.GUI.Properties.Resources.delete_16x16;
-            this.btnFileSaveDefaultDirectoryClear.Location = new System.Drawing.Point(574, 85);
+            this.btnFileSaveDefaultDirectoryClear.Location = new System.Drawing.Point(571, 99);
             this.btnFileSaveDefaultDirectoryClear.Name = "btnFileSaveDefaultDirectoryClear";
             this.btnFileSaveDefaultDirectoryClear.Size = new System.Drawing.Size(30, 24);
-            this.btnFileSaveDefaultDirectoryClear.TabIndex = 22;
+            this.btnFileSaveDefaultDirectoryClear.TabIndex = 68;
             this.btnFileSaveDefaultDirectoryClear.UseVisualStyleBackColor = true;
             this.btnFileSaveDefaultDirectoryClear.Click += new System.EventHandler(this.EventClick);
             // 
             // btnFileSaveDefaultDirectorySearch
             // 
             this.btnFileSaveDefaultDirectorySearch.Image = global::UVtools.GUI.Properties.Resources.Open_16x16;
-            this.btnFileSaveDefaultDirectorySearch.Location = new System.Drawing.Point(538, 85);
+            this.btnFileSaveDefaultDirectorySearch.Location = new System.Drawing.Point(535, 99);
             this.btnFileSaveDefaultDirectorySearch.Name = "btnFileSaveDefaultDirectorySearch";
             this.btnFileSaveDefaultDirectorySearch.Size = new System.Drawing.Size(30, 24);
-            this.btnFileSaveDefaultDirectorySearch.TabIndex = 21;
+            this.btnFileSaveDefaultDirectorySearch.TabIndex = 67;
             this.btnFileSaveDefaultDirectorySearch.UseVisualStyleBackColor = true;
             this.btnFileSaveDefaultDirectorySearch.Click += new System.EventHandler(this.EventClick);
             // 
             // label30
             // 
             this.label30.AutoSize = true;
-            this.label30.Location = new System.Drawing.Point(6, 88);
+            this.label30.Location = new System.Drawing.Point(3, 102);
             this.label30.Name = "label30";
-            this.label30.Size = new System.Drawing.Size(198, 18);
-            this.label30.TabIndex = 20;
-            this.label30.Text = "File save as default directory:";
+            this.label30.Size = new System.Drawing.Size(207, 18);
+            this.label30.TabIndex = 66;
+            this.label30.Text = "File Save As Default Directory:";
             // 
             // tbFileSaveDefaultDirectory
             // 
-            this.tbFileSaveDefaultDirectory.Location = new System.Drawing.Point(225, 85);
+            this.tbFileSaveDefaultDirectory.Location = new System.Drawing.Point(222, 99);
             this.tbFileSaveDefaultDirectory.Name = "tbFileSaveDefaultDirectory";
             this.tbFileSaveDefaultDirectory.ReadOnly = true;
             this.tbFileSaveDefaultDirectory.Size = new System.Drawing.Size(307, 24);
-            this.tbFileSaveDefaultDirectory.TabIndex = 19;
+            this.tbFileSaveDefaultDirectory.TabIndex = 65;
             // 
             // btnFileOpenDefaultDirectoryClear
             // 
             this.btnFileOpenDefaultDirectoryClear.Image = global::UVtools.GUI.Properties.Resources.delete_16x16;
-            this.btnFileOpenDefaultDirectoryClear.Location = new System.Drawing.Point(574, 55);
+            this.btnFileOpenDefaultDirectoryClear.Location = new System.Drawing.Point(571, 65);
             this.btnFileOpenDefaultDirectoryClear.Name = "btnFileOpenDefaultDirectoryClear";
             this.btnFileOpenDefaultDirectoryClear.Size = new System.Drawing.Size(30, 24);
-            this.btnFileOpenDefaultDirectoryClear.TabIndex = 18;
+            this.btnFileOpenDefaultDirectoryClear.TabIndex = 64;
             this.btnFileOpenDefaultDirectoryClear.UseVisualStyleBackColor = true;
             this.btnFileOpenDefaultDirectoryClear.Click += new System.EventHandler(this.EventClick);
             // 
             // btnFileOpenDefaultDirectorySearch
             // 
             this.btnFileOpenDefaultDirectorySearch.Image = global::UVtools.GUI.Properties.Resources.Open_16x16;
-            this.btnFileOpenDefaultDirectorySearch.Location = new System.Drawing.Point(538, 55);
+            this.btnFileOpenDefaultDirectorySearch.Location = new System.Drawing.Point(535, 65);
             this.btnFileOpenDefaultDirectorySearch.Name = "btnFileOpenDefaultDirectorySearch";
             this.btnFileOpenDefaultDirectorySearch.Size = new System.Drawing.Size(30, 24);
-            this.btnFileOpenDefaultDirectorySearch.TabIndex = 17;
+            this.btnFileOpenDefaultDirectorySearch.TabIndex = 63;
             this.btnFileOpenDefaultDirectorySearch.UseVisualStyleBackColor = true;
             this.btnFileOpenDefaultDirectorySearch.Click += new System.EventHandler(this.EventClick);
             // 
             // label29
             // 
             this.label29.AutoSize = true;
-            this.label29.Location = new System.Drawing.Point(6, 58);
+            this.label29.Location = new System.Drawing.Point(3, 68);
             this.label29.Name = "label29";
-            this.label29.Size = new System.Drawing.Size(180, 18);
-            this.label29.TabIndex = 16;
-            this.label29.Text = "File open default directory:";
+            this.label29.Size = new System.Drawing.Size(189, 18);
+            this.label29.TabIndex = 62;
+            this.label29.Text = "File Open Default Directory:";
             // 
             // tbFileOpenDefaultDirectory
             // 
-            this.tbFileOpenDefaultDirectory.Location = new System.Drawing.Point(225, 55);
+            this.tbFileOpenDefaultDirectory.Location = new System.Drawing.Point(222, 65);
             this.tbFileOpenDefaultDirectory.Name = "tbFileOpenDefaultDirectory";
             this.tbFileOpenDefaultDirectory.ReadOnly = true;
             this.tbFileOpenDefaultDirectory.Size = new System.Drawing.Size(307, 24);
-            this.tbFileOpenDefaultDirectory.TabIndex = 15;
+            this.tbFileOpenDefaultDirectory.TabIndex = 61;
             // 
             // label22
             // 
             this.label22.AutoSize = true;
-            this.label22.Location = new System.Drawing.Point(6, 27);
+            this.label22.Location = new System.Drawing.Point(3, 33);
             this.label22.Name = "label22";
-            this.label22.Size = new System.Drawing.Size(214, 18);
-            this.label22.TabIndex = 9;
-            this.label22.Text = "File load default view extension:";
+            this.label22.Size = new System.Drawing.Size(165, 18);
+            this.label22.TabIndex = 55;
+            this.label22.Text = "File Open Dialog Filters:";
             // 
             // cbDefaultOpenFileExtension
             // 
             this.cbDefaultOpenFileExtension.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.cbDefaultOpenFileExtension.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cbDefaultOpenFileExtension.FormattingEnabled = true;
-            this.cbDefaultOpenFileExtension.Location = new System.Drawing.Point(225, 23);
+            this.cbDefaultOpenFileExtension.Location = new System.Drawing.Point(222, 29);
             this.cbDefaultOpenFileExtension.Name = "cbDefaultOpenFileExtension";
             this.cbDefaultOpenFileExtension.Size = new System.Drawing.Size(379, 26);
-            this.cbDefaultOpenFileExtension.TabIndex = 8;
+            this.cbDefaultOpenFileExtension.TabIndex = 54;
+            this.toolTip.SetToolTip(this.cbDefaultOpenFileExtension, "Sets default file extensions that will be filtered by the File Open Dialog Box.");
             // 
             // label28
             // 
             this.label28.AutoSize = true;
-            this.label28.Location = new System.Drawing.Point(361, 206);
+            this.label28.Location = new System.Drawing.Point(358, 236);
             this.label28.Name = "label28";
             this.label28.Size = new System.Drawing.Size(48, 18);
-            this.label28.TabIndex = 14;
+            this.label28.TabIndex = 60;
             this.label28.Text = "Suffix:";
             // 
             // cbFileSavePromptOverwrite
             // 
             this.cbFileSavePromptOverwrite.AutoSize = true;
-            this.cbFileSavePromptOverwrite.Location = new System.Drawing.Point(9, 175);
+            this.cbFileSavePromptOverwrite.Location = new System.Drawing.Point(6, 201);
             this.cbFileSavePromptOverwrite.Name = "cbFileSavePromptOverwrite";
             this.cbFileSavePromptOverwrite.Size = new System.Drawing.Size(381, 22);
-            this.cbFileSavePromptOverwrite.TabIndex = 10;
+            this.cbFileSavePromptOverwrite.TabIndex = 56;
             this.cbFileSavePromptOverwrite.Text = "On file \"Save\" prompt for file overwrite for the first time";
             this.cbFileSavePromptOverwrite.UseVisualStyleBackColor = true;
             // 
             // tbFileSaveNameSuffix
             // 
-            this.tbFileSaveNameSuffix.Location = new System.Drawing.Point(420, 203);
+            this.tbFileSaveNameSuffix.Location = new System.Drawing.Point(417, 233);
             this.tbFileSaveNameSuffix.Name = "tbFileSaveNameSuffix";
             this.tbFileSaveNameSuffix.Size = new System.Drawing.Size(184, 24);
-            this.tbFileSaveNameSuffix.TabIndex = 13;
+            this.tbFileSaveNameSuffix.TabIndex = 59;
             // 
             // label27
             // 
             this.label27.AutoSize = true;
-            this.label27.Location = new System.Drawing.Point(9, 206);
+            this.label27.Location = new System.Drawing.Point(6, 236);
             this.label27.Name = "label27";
             this.label27.Size = new System.Drawing.Size(147, 18);
-            this.label27.TabIndex = 11;
+            this.label27.TabIndex = 57;
             this.label27.Text = "File \"Save as\" Preffix:";
             // 
             // tbFileSaveNamePreffix
             // 
-            this.tbFileSaveNamePreffix.Location = new System.Drawing.Point(162, 203);
+            this.tbFileSaveNamePreffix.Location = new System.Drawing.Point(159, 233);
             this.tbFileSaveNamePreffix.Name = "tbFileSaveNamePreffix";
             this.tbFileSaveNamePreffix.Size = new System.Drawing.Size(184, 24);
-            this.tbFileSaveNamePreffix.TabIndex = 12;
-            // 
-            // groupBox4
-            // 
-            this.groupBox4.Controls.Add(this.cbStartMaximized);
-            this.groupBox4.Controls.Add(this.cbCheckForUpdatesOnStartup);
-            this.groupBox4.Dock = System.Windows.Forms.DockStyle.Top;
-            this.groupBox4.Location = new System.Drawing.Point(3, 3);
-            this.groupBox4.Name = "groupBox4";
-            this.groupBox4.Size = new System.Drawing.Size(610, 83);
-            this.groupBox4.TabIndex = 15;
-            this.groupBox4.TabStop = false;
-            this.groupBox4.Text = "Startup";
+            this.tbFileSaveNamePreffix.TabIndex = 58;
             // 
             // tabPage2
             // 
-            this.tabPage2.Controls.Add(this.cbZoomIssuesAuto);
-            this.tabPage2.Controls.Add(this.label40);
-            this.tabPage2.Controls.Add(this.label41);
-            this.tabPage2.Controls.Add(this.nmCrosshairLineMargin);
-            this.tabPage2.Controls.Add(this.label39);
-            this.tabPage2.Controls.Add(this.label37);
-            this.tabPage2.Controls.Add(this.label36);
-            this.tabPage2.Controls.Add(this.cbCrosshairShowOnlyOnSelectedIssues);
-            this.tabPage2.Controls.Add(this.label38);
-            this.tabPage2.Controls.Add(this.nmCrosshairLineLength);
-            this.tabPage2.Controls.Add(this.cbCrosshairFadeLevel);
-            this.tabPage2.Controls.Add(this.cbZoomIssues);
-            this.tabPage2.Controls.Add(this.cbZoomLockLevel);
-            this.tabPage2.Controls.Add(this.cbZoomToFitPrintVolumeBounds);
-            this.tabPage2.Controls.Add(this.label1);
-            this.tabPage2.Controls.Add(this.label2);
-            this.tabPage2.Controls.Add(this.cbOutlineHollowAreas);
-            this.tabPage2.Controls.Add(this.btnPreviousNextLayerColor);
-            this.tabPage2.Controls.Add(this.btnPreviousLayerColor);
-            this.tabPage2.Controls.Add(this.label18);
-            this.tabPage2.Controls.Add(this.btnIslandColor);
-            this.tabPage2.Controls.Add(this.btnIslandHLColor);
-            this.tabPage2.Controls.Add(this.cbLayerAutoRotateBestView);
-            this.tabPage2.Controls.Add(this.nmOutlineHollowAreasLineThickness);
-            this.tabPage2.Controls.Add(this.label3);
-            this.tabPage2.Controls.Add(this.cbLayerDifferenceDefault);
-            this.tabPage2.Controls.Add(this.label19);
-            this.tabPage2.Controls.Add(this.btnResinTrapColor);
-            this.tabPage2.Controls.Add(this.btnResinTrapHLColor);
-            this.tabPage2.Controls.Add(this.cbLayerZoomToFit);
-            this.tabPage2.Controls.Add(this.btnOutlineHollowAreasColor);
-            this.tabPage2.Controls.Add(this.btnNextLayerColor);
-            this.tabPage2.Controls.Add(this.btnOutlinePrintVolumeBoundsColor);
-            this.tabPage2.Controls.Add(this.cbOutlineLayerBounds);
-            this.tabPage2.Controls.Add(this.label6);
-            this.tabPage2.Controls.Add(this.label14);
-            this.tabPage2.Controls.Add(this.label16);
-            this.tabPage2.Controls.Add(this.label4);
-            this.tabPage2.Controls.Add(this.nmOutlinePrintVolumeBoundsLineThickness);
-            this.tabPage2.Controls.Add(this.nmOutlineLayerBoundsLineThickness);
-            this.tabPage2.Controls.Add(this.label5);
-            this.tabPage2.Controls.Add(this.label15);
-            this.tabPage2.Controls.Add(this.label17);
-            this.tabPage2.Controls.Add(this.btnTouchingBoundsColor);
-            this.tabPage2.Controls.Add(this.cbOutlinePrintVolumeBounds);
-            this.tabPage2.Controls.Add(this.btnOutlineLayerBoundsColor);
+            this.tabPage2.Controls.Add(this.groupBox6);
+            this.tabPage2.Controls.Add(this.groupBox7);
+            this.tabPage2.Controls.Add(this.groupBox8);
+            this.tabPage2.Controls.Add(this.groupBox9);
             this.tabPage2.Location = new System.Drawing.Point(4, 27);
             this.tabPage2.Name = "tabPage2";
             this.tabPage2.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage2.Size = new System.Drawing.Size(616, 594);
+            this.tabPage2.Size = new System.Drawing.Size(616, 630);
             this.tabPage2.TabIndex = 1;
             this.tabPage2.Text = "Layer Preview";
             this.tabPage2.UseVisualStyleBackColor = true;
+            // 
+            // groupBox6
+            // 
+            this.groupBox6.Controls.Add(this.label1);
+            this.groupBox6.Controls.Add(this.label2);
+            this.groupBox6.Controls.Add(this.cbOutlineHollowAreas);
+            this.groupBox6.Controls.Add(this.btnPreviousNextLayerColor);
+            this.groupBox6.Controls.Add(this.btnPreviousLayerColor);
+            this.groupBox6.Controls.Add(this.label18);
+            this.groupBox6.Controls.Add(this.btnIslandColor);
+            this.groupBox6.Controls.Add(this.btnIslandHLColor);
+            this.groupBox6.Controls.Add(this.nmOutlineHollowAreasLineThickness);
+            this.groupBox6.Controls.Add(this.label3);
+            this.groupBox6.Controls.Add(this.cbLayerDifferenceDefault);
+            this.groupBox6.Controls.Add(this.label19);
+            this.groupBox6.Controls.Add(this.btnResinTrapColor);
+            this.groupBox6.Controls.Add(this.btnResinTrapHLColor);
+            this.groupBox6.Controls.Add(this.btnOutlineHollowAreasColor);
+            this.groupBox6.Controls.Add(this.btnNextLayerColor);
+            this.groupBox6.Controls.Add(this.btnOutlinePrintVolumeBoundsColor);
+            this.groupBox6.Controls.Add(this.cbOutlineLayerBounds);
+            this.groupBox6.Controls.Add(this.label6);
+            this.groupBox6.Controls.Add(this.label14);
+            this.groupBox6.Controls.Add(this.label16);
+            this.groupBox6.Controls.Add(this.label4);
+            this.groupBox6.Controls.Add(this.nmOutlineLayerBoundsLineThickness);
+            this.groupBox6.Controls.Add(this.label5);
+            this.groupBox6.Controls.Add(this.label15);
+            this.groupBox6.Controls.Add(this.label17);
+            this.groupBox6.Controls.Add(this.btnTouchingBoundsColor);
+            this.groupBox6.Controls.Add(this.cbOutlinePrintVolumeBounds);
+            this.groupBox6.Controls.Add(this.btnOutlineLayerBoundsColor);
+            this.groupBox6.Controls.Add(this.label37);
+            this.groupBox6.Controls.Add(this.nmOutlinePrintVolumeBoundsLineThickness);
+            this.groupBox6.Controls.Add(this.btnCrosshairColor);
+            this.groupBox6.Location = new System.Drawing.Point(5, 9);
+            this.groupBox6.Name = "groupBox6";
+            this.groupBox6.Size = new System.Drawing.Size(604, 255);
+            this.groupBox6.TabIndex = 53;
+            this.groupBox6.TabStop = false;
+            this.groupBox6.Text = "Layer Colors";
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(11, 180);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(201, 18);
+            this.label1.TabIndex = 39;
+            this.label1.Text = "Prev && Next Layer Difference:";
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(11, 116);
+            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(181, 18);
+            this.label2.TabIndex = 34;
+            this.label2.Text = "Previous Layer Difference:";
+            // 
+            // cbOutlineHollowAreas
+            // 
+            this.cbOutlineHollowAreas.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.cbOutlineHollowAreas.AutoSize = true;
+            this.cbOutlineHollowAreas.Location = new System.Drawing.Point(415, 85);
+            this.cbOutlineHollowAreas.Name = "cbOutlineHollowAreas";
+            this.cbOutlineHollowAreas.Size = new System.Drawing.Size(134, 22);
+            this.cbOutlineHollowAreas.TabIndex = 46;
+            this.cbOutlineHollowAreas.Text = "Show by Default";
+            this.toolTip.SetToolTip(this.cbOutlineHollowAreas, "Determines the default state of the \'Hollow Area Outline\' toolstrip setting.");
+            this.cbOutlineHollowAreas.UseVisualStyleBackColor = true;
+            // 
+            // btnPreviousNextLayerColor
+            // 
+            this.btnPreviousNextLayerColor.BackColor = System.Drawing.Color.White;
+            this.btnPreviousNextLayerColor.FlatAppearance.BorderColor = System.Drawing.Color.Black;
+            this.btnPreviousNextLayerColor.FlatAppearance.BorderSize = 2;
+            this.btnPreviousNextLayerColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnPreviousNextLayerColor.Location = new System.Drawing.Point(219, 178);
+            this.btnPreviousNextLayerColor.Margin = new System.Windows.Forms.Padding(4);
+            this.btnPreviousNextLayerColor.Name = "btnPreviousNextLayerColor";
+            this.btnPreviousNextLayerColor.Size = new System.Drawing.Size(24, 24);
+            this.btnPreviousNextLayerColor.TabIndex = 52;
+            this.toolTip.SetToolTip(this.btnPreviousNextLayerColor, "Pixels present on the previous layer and the next layer, but not on the current l" +
+        "ayer.");
+            this.btnPreviousNextLayerColor.UseVisualStyleBackColor = false;
+            this.btnPreviousNextLayerColor.Click += new System.EventHandler(this.EventClick);
+            // 
+            // btnPreviousLayerColor
+            // 
+            this.btnPreviousLayerColor.BackColor = System.Drawing.Color.White;
+            this.btnPreviousLayerColor.FlatAppearance.BorderColor = System.Drawing.Color.Black;
+            this.btnPreviousLayerColor.FlatAppearance.BorderSize = 2;
+            this.btnPreviousLayerColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnPreviousLayerColor.Location = new System.Drawing.Point(219, 114);
+            this.btnPreviousLayerColor.Margin = new System.Windows.Forms.Padding(4);
+            this.btnPreviousLayerColor.Name = "btnPreviousLayerColor";
+            this.btnPreviousLayerColor.Size = new System.Drawing.Size(24, 24);
+            this.btnPreviousLayerColor.TabIndex = 48;
+            this.toolTip.SetToolTip(this.btnPreviousLayerColor, "Pixels present on the previous layer, but not on the current layer.  Represents w" +
+        "here the current layer has receeded.");
+            this.btnPreviousLayerColor.UseVisualStyleBackColor = false;
+            this.btnPreviousLayerColor.Click += new System.EventHandler(this.EventClick);
+            // 
+            // label18
+            // 
+            this.label18.AutoSize = true;
+            this.label18.Location = new System.Drawing.Point(295, 85);
+            this.label18.Name = "label18";
+            this.label18.Size = new System.Drawing.Size(107, 18);
+            this.label18.TabIndex = 64;
+            this.label18.Text = "Line Thickness";
+            // 
+            // btnIslandColor
+            // 
+            this.btnIslandColor.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnIslandColor.BackColor = System.Drawing.Color.White;
+            this.btnIslandColor.FlatAppearance.BorderColor = System.Drawing.Color.Black;
+            this.btnIslandColor.FlatAppearance.BorderSize = 2;
+            this.btnIslandColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnIslandColor.Location = new System.Drawing.Point(538, 118);
+            this.btnIslandColor.Margin = new System.Windows.Forms.Padding(4);
+            this.btnIslandColor.Name = "btnIslandColor";
+            this.btnIslandColor.Size = new System.Drawing.Size(24, 24);
+            this.btnIslandColor.TabIndex = 53;
+            this.toolTip.SetToolTip(this.btnIslandColor, "Islands on the layer that are not currently selected.");
+            this.btnIslandColor.UseVisualStyleBackColor = false;
+            this.btnIslandColor.Click += new System.EventHandler(this.EventClick);
+            // 
+            // btnIslandHLColor
+            // 
+            this.btnIslandHLColor.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnIslandHLColor.BackColor = System.Drawing.Color.White;
+            this.btnIslandHLColor.FlatAppearance.BorderColor = System.Drawing.Color.Black;
+            this.btnIslandHLColor.FlatAppearance.BorderSize = 2;
+            this.btnIslandHLColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnIslandHLColor.Location = new System.Drawing.Point(570, 118);
+            this.btnIslandHLColor.Margin = new System.Windows.Forms.Padding(4);
+            this.btnIslandHLColor.Name = "btnIslandHLColor";
+            this.btnIslandHLColor.Size = new System.Drawing.Size(24, 24);
+            this.btnIslandHLColor.TabIndex = 54;
+            this.toolTip.SetToolTip(this.btnIslandHLColor, "Islands on the layer that are currently selected in the issue list.");
+            this.btnIslandHLColor.UseVisualStyleBackColor = false;
+            this.btnIslandHLColor.Click += new System.EventHandler(this.EventClick);
+            // 
+            // nmOutlineHollowAreasLineThickness
+            // 
+            this.nmOutlineHollowAreasLineThickness.Location = new System.Drawing.Point(253, 83);
+            this.nmOutlineHollowAreasLineThickness.Maximum = new decimal(new int[] {
+            50,
+            0,
+            0,
+            0});
+            this.nmOutlineHollowAreasLineThickness.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            -2147483648});
+            this.nmOutlineHollowAreasLineThickness.Name = "nmOutlineHollowAreasLineThickness";
+            this.nmOutlineHollowAreasLineThickness.Size = new System.Drawing.Size(40, 24);
+            this.nmOutlineHollowAreasLineThickness.TabIndex = 45;
+            this.toolTip.SetToolTip(this.nmOutlineHollowAreasLineThickness, "Range -1 to 50, -1 for fill");
+            this.nmOutlineHollowAreasLineThickness.Value = new decimal(new int[] {
+            2,
+            0,
+            0,
+            0});
+            // 
+            // label3
+            // 
+            this.label3.AutoSize = true;
+            this.label3.Location = new System.Drawing.Point(11, 148);
+            this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(153, 18);
+            this.label3.TabIndex = 37;
+            this.label3.Text = "Next Layer Difference:";
+            // 
+            // cbLayerDifferenceDefault
+            // 
+            this.cbLayerDifferenceDefault.AutoSize = true;
+            this.cbLayerDifferenceDefault.Location = new System.Drawing.Point(14, 213);
+            this.cbLayerDifferenceDefault.Name = "cbLayerDifferenceDefault";
+            this.cbLayerDifferenceDefault.Size = new System.Drawing.Size(249, 22);
+            this.cbLayerDifferenceDefault.TabIndex = 59;
+            this.cbLayerDifferenceDefault.Text = "Show Layer Diff Colors by Default";
+            this.toolTip.SetToolTip(this.cbLayerDifferenceDefault, "Determines whether differences will be visulaized by default by setting the defau" +
+        "lt state of the \'Difference\' toolstrip button");
+            this.cbLayerDifferenceDefault.UseVisualStyleBackColor = true;
+            // 
+            // label19
+            // 
+            this.label19.AutoSize = true;
+            this.label19.Location = new System.Drawing.Point(11, 85);
+            this.label19.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label19.Name = "label19";
+            this.label19.Size = new System.Drawing.Size(142, 18);
+            this.label19.TabIndex = 63;
+            this.label19.Text = "Hollow Area Outline:";
+            // 
+            // btnResinTrapColor
+            // 
+            this.btnResinTrapColor.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnResinTrapColor.BackColor = System.Drawing.Color.White;
+            this.btnResinTrapColor.FlatAppearance.BorderColor = System.Drawing.Color.Black;
+            this.btnResinTrapColor.FlatAppearance.BorderSize = 2;
+            this.btnResinTrapColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnResinTrapColor.Location = new System.Drawing.Point(538, 150);
+            this.btnResinTrapColor.Margin = new System.Windows.Forms.Padding(4);
+            this.btnResinTrapColor.Name = "btnResinTrapColor";
+            this.btnResinTrapColor.Size = new System.Drawing.Size(24, 24);
+            this.btnResinTrapColor.TabIndex = 55;
+            this.toolTip.SetToolTip(this.btnResinTrapColor, "Resin Traps on the layer that are not currently selected.");
+            this.btnResinTrapColor.UseVisualStyleBackColor = false;
+            this.btnResinTrapColor.Click += new System.EventHandler(this.EventClick);
+            // 
+            // btnResinTrapHLColor
+            // 
+            this.btnResinTrapHLColor.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnResinTrapHLColor.BackColor = System.Drawing.Color.White;
+            this.btnResinTrapHLColor.FlatAppearance.BorderColor = System.Drawing.Color.Black;
+            this.btnResinTrapHLColor.FlatAppearance.BorderSize = 2;
+            this.btnResinTrapHLColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnResinTrapHLColor.Location = new System.Drawing.Point(570, 150);
+            this.btnResinTrapHLColor.Margin = new System.Windows.Forms.Padding(4);
+            this.btnResinTrapHLColor.Name = "btnResinTrapHLColor";
+            this.btnResinTrapHLColor.Size = new System.Drawing.Size(24, 24);
+            this.btnResinTrapHLColor.TabIndex = 56;
+            this.toolTip.SetToolTip(this.btnResinTrapHLColor, "Resin Traps on the layer that are currently selected in the issue list.");
+            this.btnResinTrapHLColor.UseVisualStyleBackColor = false;
+            this.btnResinTrapHLColor.Click += new System.EventHandler(this.EventClick);
+            // 
+            // btnOutlineHollowAreasColor
+            // 
+            this.btnOutlineHollowAreasColor.BackColor = System.Drawing.Color.White;
+            this.btnOutlineHollowAreasColor.FlatAppearance.BorderColor = System.Drawing.Color.Black;
+            this.btnOutlineHollowAreasColor.FlatAppearance.BorderSize = 2;
+            this.btnOutlineHollowAreasColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnOutlineHollowAreasColor.Location = new System.Drawing.Point(219, 83);
+            this.btnOutlineHollowAreasColor.Margin = new System.Windows.Forms.Padding(4);
+            this.btnOutlineHollowAreasColor.Name = "btnOutlineHollowAreasColor";
+            this.btnOutlineHollowAreasColor.Size = new System.Drawing.Size(24, 24);
+            this.btnOutlineHollowAreasColor.TabIndex = 43;
+            this.toolTip.SetToolTip(this.btnOutlineHollowAreasColor, "Color used to outline (or fill) hollow areas on the layer.");
+            this.btnOutlineHollowAreasColor.UseVisualStyleBackColor = false;
+            this.btnOutlineHollowAreasColor.Click += new System.EventHandler(this.EventClick);
+            // 
+            // btnNextLayerColor
+            // 
+            this.btnNextLayerColor.BackColor = System.Drawing.Color.White;
+            this.btnNextLayerColor.FlatAppearance.BorderColor = System.Drawing.Color.Black;
+            this.btnNextLayerColor.FlatAppearance.BorderSize = 2;
+            this.btnNextLayerColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnNextLayerColor.Location = new System.Drawing.Point(219, 146);
+            this.btnNextLayerColor.Margin = new System.Windows.Forms.Padding(4);
+            this.btnNextLayerColor.Name = "btnNextLayerColor";
+            this.btnNextLayerColor.Size = new System.Drawing.Size(24, 24);
+            this.btnNextLayerColor.TabIndex = 50;
+            this.toolTip.SetToolTip(this.btnNextLayerColor, "Pixels present on the next layer, but not on the current layer.  Represens where " +
+        "the next layer will grow.");
+            this.btnNextLayerColor.UseVisualStyleBackColor = false;
+            this.btnNextLayerColor.Click += new System.EventHandler(this.EventClick);
+            // 
+            // btnOutlinePrintVolumeBoundsColor
+            // 
+            this.btnOutlinePrintVolumeBoundsColor.BackColor = System.Drawing.Color.White;
+            this.btnOutlinePrintVolumeBoundsColor.FlatAppearance.BorderColor = System.Drawing.Color.Black;
+            this.btnOutlinePrintVolumeBoundsColor.FlatAppearance.BorderSize = 2;
+            this.btnOutlinePrintVolumeBoundsColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnOutlinePrintVolumeBoundsColor.Location = new System.Drawing.Point(219, 19);
+            this.btnOutlinePrintVolumeBoundsColor.Margin = new System.Windows.Forms.Padding(4);
+            this.btnOutlinePrintVolumeBoundsColor.Name = "btnOutlinePrintVolumeBoundsColor";
+            this.btnOutlinePrintVolumeBoundsColor.Size = new System.Drawing.Size(24, 24);
+            this.btnOutlinePrintVolumeBoundsColor.TabIndex = 35;
+            this.toolTip.SetToolTip(this.btnOutlinePrintVolumeBoundsColor, "Color used to draw the bounding rectangle around the print volume.");
+            this.btnOutlinePrintVolumeBoundsColor.UseVisualStyleBackColor = false;
+            this.btnOutlinePrintVolumeBoundsColor.Click += new System.EventHandler(this.EventClick);
+            // 
+            // cbOutlineLayerBounds
+            // 
+            this.cbOutlineLayerBounds.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.cbOutlineLayerBounds.AutoSize = true;
+            this.cbOutlineLayerBounds.Location = new System.Drawing.Point(415, 53);
+            this.cbOutlineLayerBounds.Name = "cbOutlineLayerBounds";
+            this.cbOutlineLayerBounds.Size = new System.Drawing.Size(134, 22);
+            this.cbOutlineLayerBounds.TabIndex = 42;
+            this.cbOutlineLayerBounds.Text = "Show by Default";
+            this.toolTip.SetToolTip(this.cbOutlineLayerBounds, "Determines the default state of the \'Layer Boundary\' toolstrip setting.");
+            this.cbOutlineLayerBounds.UseVisualStyleBackColor = true;
+            // 
+            // label6
+            // 
+            this.label6.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.label6.AutoSize = true;
+            this.label6.Location = new System.Drawing.Point(396, 184);
+            this.label6.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label6.Name = "label6";
+            this.label6.Size = new System.Drawing.Size(140, 18);
+            this.label6.TabIndex = 49;
+            this.label6.Text = "Touching Boundary:";
+            // 
+            // label14
+            // 
+            this.label14.AutoSize = true;
+            this.label14.Location = new System.Drawing.Point(11, 21);
+            this.label14.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label14.Name = "label14";
+            this.label14.Size = new System.Drawing.Size(163, 18);
+            this.label14.TabIndex = 58;
+            this.label14.Text = "Print Volume Boundary:";
+            // 
+            // label16
+            // 
+            this.label16.AutoSize = true;
+            this.label16.Location = new System.Drawing.Point(295, 53);
+            this.label16.Name = "label16";
+            this.label16.Size = new System.Drawing.Size(107, 18);
+            this.label16.TabIndex = 62;
+            this.label16.Text = "Line Thickness";
+            // 
+            // label4
+            // 
+            this.label4.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.label4.AutoSize = true;
+            this.label4.Location = new System.Drawing.Point(375, 120);
+            this.label4.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(161, 18);
+            this.label4.TabIndex = 44;
+            this.label4.Text = "Island / Selected Island:";
+            // 
+            // nmOutlineLayerBoundsLineThickness
+            // 
+            this.nmOutlineLayerBoundsLineThickness.Location = new System.Drawing.Point(253, 51);
+            this.nmOutlineLayerBoundsLineThickness.Maximum = new decimal(new int[] {
+            50,
+            0,
+            0,
+            0});
+            this.nmOutlineLayerBoundsLineThickness.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.nmOutlineLayerBoundsLineThickness.Name = "nmOutlineLayerBoundsLineThickness";
+            this.nmOutlineLayerBoundsLineThickness.Size = new System.Drawing.Size(40, 24);
+            this.nmOutlineLayerBoundsLineThickness.TabIndex = 41;
+            this.toolTip.SetToolTip(this.nmOutlineLayerBoundsLineThickness, "Range 1 to 50");
+            this.nmOutlineLayerBoundsLineThickness.Value = new decimal(new int[] {
+            2,
+            0,
+            0,
+            0});
+            // 
+            // label5
+            // 
+            this.label5.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.label5.AutoSize = true;
+            this.label5.Location = new System.Drawing.Point(312, 152);
+            this.label5.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(224, 18);
+            this.label5.TabIndex = 47;
+            this.label5.Text = "Resin trap / Selected Resin Trap:";
+            // 
+            // label15
+            // 
+            this.label15.AutoSize = true;
+            this.label15.Location = new System.Drawing.Point(295, 21);
+            this.label15.Name = "label15";
+            this.label15.Size = new System.Drawing.Size(107, 18);
+            this.label15.TabIndex = 60;
+            this.label15.Text = "Line Thickness";
+            // 
+            // label17
+            // 
+            this.label17.AutoSize = true;
+            this.label17.Location = new System.Drawing.Point(11, 53);
+            this.label17.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label17.Name = "label17";
+            this.label17.Size = new System.Drawing.Size(115, 18);
+            this.label17.TabIndex = 61;
+            this.label17.Text = "Layer Boundary:";
+            // 
+            // btnTouchingBoundsColor
+            // 
+            this.btnTouchingBoundsColor.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnTouchingBoundsColor.BackColor = System.Drawing.Color.White;
+            this.btnTouchingBoundsColor.FlatAppearance.BorderColor = System.Drawing.Color.Black;
+            this.btnTouchingBoundsColor.FlatAppearance.BorderSize = 2;
+            this.btnTouchingBoundsColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnTouchingBoundsColor.Location = new System.Drawing.Point(538, 182);
+            this.btnTouchingBoundsColor.Margin = new System.Windows.Forms.Padding(4);
+            this.btnTouchingBoundsColor.Name = "btnTouchingBoundsColor";
+            this.btnTouchingBoundsColor.Size = new System.Drawing.Size(24, 24);
+            this.btnTouchingBoundsColor.TabIndex = 57;
+            this.toolTip.SetToolTip(this.btnTouchingBoundsColor, "Pixels that are touching the plate boundary.");
+            this.btnTouchingBoundsColor.UseVisualStyleBackColor = false;
+            this.btnTouchingBoundsColor.Click += new System.EventHandler(this.EventClick);
+            // 
+            // cbOutlinePrintVolumeBounds
+            // 
+            this.cbOutlinePrintVolumeBounds.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.cbOutlinePrintVolumeBounds.AutoSize = true;
+            this.cbOutlinePrintVolumeBounds.Location = new System.Drawing.Point(415, 21);
+            this.cbOutlinePrintVolumeBounds.Name = "cbOutlinePrintVolumeBounds";
+            this.cbOutlinePrintVolumeBounds.Size = new System.Drawing.Size(134, 22);
+            this.cbOutlinePrintVolumeBounds.TabIndex = 38;
+            this.cbOutlinePrintVolumeBounds.Text = "Show by Default";
+            this.toolTip.SetToolTip(this.cbOutlinePrintVolumeBounds, "Determines the default state of the \'Print Volume Boundary\' toolstrip setting.");
+            this.cbOutlinePrintVolumeBounds.UseVisualStyleBackColor = true;
+            // 
+            // btnOutlineLayerBoundsColor
+            // 
+            this.btnOutlineLayerBoundsColor.BackColor = System.Drawing.Color.White;
+            this.btnOutlineLayerBoundsColor.FlatAppearance.BorderColor = System.Drawing.Color.Black;
+            this.btnOutlineLayerBoundsColor.FlatAppearance.BorderSize = 2;
+            this.btnOutlineLayerBoundsColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnOutlineLayerBoundsColor.Location = new System.Drawing.Point(219, 51);
+            this.btnOutlineLayerBoundsColor.Margin = new System.Windows.Forms.Padding(4);
+            this.btnOutlineLayerBoundsColor.Name = "btnOutlineLayerBoundsColor";
+            this.btnOutlineLayerBoundsColor.Size = new System.Drawing.Size(24, 24);
+            this.btnOutlineLayerBoundsColor.TabIndex = 40;
+            this.toolTip.SetToolTip(this.btnOutlineLayerBoundsColor, "Color used to draw the bounding rectangle around the layer.");
+            this.btnOutlineLayerBoundsColor.UseVisualStyleBackColor = false;
+            this.btnOutlineLayerBoundsColor.Click += new System.EventHandler(this.EventClick);
+            // 
+            // label37
+            // 
+            this.label37.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.label37.AutoSize = true;
+            this.label37.Location = new System.Drawing.Point(459, 217);
+            this.label37.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label37.Name = "label37";
+            this.label37.Size = new System.Drawing.Size(77, 18);
+            this.label37.TabIndex = 51;
+            this.label37.Text = "Crosshair:";
+            // 
+            // nmOutlinePrintVolumeBoundsLineThickness
+            // 
+            this.nmOutlinePrintVolumeBoundsLineThickness.Location = new System.Drawing.Point(253, 19);
+            this.nmOutlinePrintVolumeBoundsLineThickness.Maximum = new decimal(new int[] {
+            50,
+            0,
+            0,
+            0});
+            this.nmOutlinePrintVolumeBoundsLineThickness.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.nmOutlinePrintVolumeBoundsLineThickness.Name = "nmOutlinePrintVolumeBoundsLineThickness";
+            this.nmOutlinePrintVolumeBoundsLineThickness.Size = new System.Drawing.Size(40, 24);
+            this.nmOutlinePrintVolumeBoundsLineThickness.TabIndex = 36;
+            this.toolTip.SetToolTip(this.nmOutlinePrintVolumeBoundsLineThickness, "Range 1 to 50");
+            this.nmOutlinePrintVolumeBoundsLineThickness.Value = new decimal(new int[] {
+            2,
+            0,
+            0,
+            0});
+            // 
+            // btnCrosshairColor
+            // 
+            this.btnCrosshairColor.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnCrosshairColor.BackColor = System.Drawing.Color.White;
+            this.btnCrosshairColor.FlatAppearance.BorderColor = System.Drawing.Color.Black;
+            this.btnCrosshairColor.FlatAppearance.BorderSize = 2;
+            this.btnCrosshairColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnCrosshairColor.Location = new System.Drawing.Point(538, 214);
+            this.btnCrosshairColor.Margin = new System.Windows.Forms.Padding(4);
+            this.btnCrosshairColor.Name = "btnCrosshairColor";
+            this.btnCrosshairColor.Size = new System.Drawing.Size(24, 24);
+            this.btnCrosshairColor.TabIndex = 33;
+            this.toolTip.SetToolTip(this.btnCrosshairColor, "Pixels that are touching the plate boundary.");
+            this.btnCrosshairColor.UseVisualStyleBackColor = false;
+            this.btnCrosshairColor.Click += new System.EventHandler(this.EventClick);
+            // 
+            // groupBox7
+            // 
+            this.groupBox7.Controls.Add(this.label43);
+            this.groupBox7.Controls.Add(this.cbZoomToFit);
+            this.groupBox7.Controls.Add(this.cbZoomIssues);
+            this.groupBox7.Controls.Add(this.cbZoomIssuesAuto);
+            this.groupBox7.Controls.Add(this.label38);
+            this.groupBox7.Controls.Add(this.cbZoomLockLevel);
+            this.groupBox7.Location = new System.Drawing.Point(5, 269);
+            this.groupBox7.Name = "groupBox7";
+            this.groupBox7.Size = new System.Drawing.Size(605, 97);
+            this.groupBox7.TabIndex = 54;
+            this.groupBox7.TabStop = false;
+            this.groupBox7.Text = "Zoom";
+            // 
+            // label43
+            // 
+            this.label43.AutoSize = true;
+            this.label43.Location = new System.Drawing.Point(8, 59);
+            this.label43.Name = "label43";
+            this.label43.Size = new System.Drawing.Size(117, 18);
+            this.label43.TabIndex = 57;
+            this.label43.Text = "Zoom Out to Fit:";
+            // 
+            // cbZoomToFit
+            // 
+            this.cbZoomToFit.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.cbZoomToFit.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cbZoomToFit.DropDownWidth = 180;
+            this.cbZoomToFit.FormattingEnabled = true;
+            this.cbZoomToFit.Items.AddRange(new object[] {
+            "Print Volume Boundary",
+            "Layer Boundary"});
+            this.cbZoomToFit.Location = new System.Drawing.Point(131, 57);
+            this.cbZoomToFit.Name = "cbZoomToFit";
+            this.cbZoomToFit.Size = new System.Drawing.Size(180, 26);
+            this.cbZoomToFit.TabIndex = 55;
+            this.toolTip.SetToolTip(this.cbZoomToFit, "Determines whether double-right-click will zoom out to layer boundary or to print" +
+        " volume boundary.  Holding ALT during double-click will invert this behavior.");
+            // 
+            // cbZoomIssues
+            // 
+            this.cbZoomIssues.AutoSize = true;
+            this.cbZoomIssues.Location = new System.Drawing.Point(11, 23);
+            this.cbZoomIssues.Name = "cbZoomIssues";
+            this.cbZoomIssues.Size = new System.Drawing.Size(296, 22);
+            this.cbZoomIssues.TabIndex = 52;
+            this.cbZoomIssues.Text = "Auto Zoom && Center Issues on Selection";
+            this.toolTip.SetToolTip(this.cbZoomIssues, "Automatically zoom and center issues when they are selected.  When enabled, singl" +
+        "e-left-click will behave the same as double-left-click.");
+            this.cbZoomIssues.UseVisualStyleBackColor = true;
             // 
             // cbZoomIssuesAuto
             // 
             this.cbZoomIssuesAuto.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.cbZoomIssuesAuto.AutoSize = true;
-            this.cbZoomIssuesAuto.Location = new System.Drawing.Point(457, 305);
+            this.cbZoomIssuesAuto.Location = new System.Drawing.Point(401, 59);
             this.cbZoomIssuesAuto.Name = "cbZoomIssuesAuto";
-            this.cbZoomIssuesAuto.Size = new System.Drawing.Size(151, 22);
-            this.cbZoomIssuesAuto.TabIndex = 49;
-            this.cbZoomIssuesAuto.Text = "Auto zoom instead";
+            this.cbZoomIssuesAuto.Size = new System.Drawing.Size(196, 22);
+            this.cbZoomIssuesAuto.TabIndex = 54;
+            this.cbZoomIssuesAuto.Text = "Fit Large Issues on Zoom";
+            this.toolTip.SetToolTip(this.cbZoomIssuesAuto, "Large issues that don\'t fit on the screen when zoomed to the Zoom In Factor, will" +
+        " zoom to fit instead.");
             this.cbZoomIssuesAuto.UseVisualStyleBackColor = true;
+            // 
+            // label38
+            // 
+            this.label38.AutoSize = true;
+            this.label38.Location = new System.Drawing.Point(403, 27);
+            this.label38.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label38.Name = "label38";
+            this.label38.Size = new System.Drawing.Size(114, 18);
+            this.label38.TabIndex = 56;
+            this.label38.Text = "Zoom In Factor:";
+            // 
+            // cbZoomLockLevel
+            // 
+            this.cbZoomLockLevel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.cbZoomLockLevel.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cbZoomLockLevel.FormattingEnabled = true;
+            this.cbZoomLockLevel.Location = new System.Drawing.Point(523, 23);
+            this.cbZoomLockLevel.Name = "cbZoomLockLevel";
+            this.cbZoomLockLevel.Size = new System.Drawing.Size(68, 26);
+            this.cbZoomLockLevel.TabIndex = 53;
+            this.toolTip.SetToolTip(this.cbZoomLockLevel, "Default zoom factor to be used when zooming in via double-left-click.  This zoom " +
+        "factor can be changed on-the-fly by holding the scroll wheel for 1 second.");
+            // 
+            // groupBox8
+            // 
+            this.groupBox8.Controls.Add(this.label44);
+            this.groupBox8.Controls.Add(this.cbCrosshairShowOnlyOnSelectedIssues);
+            this.groupBox8.Controls.Add(this.cbCrosshairFadeLevel);
+            this.groupBox8.Controls.Add(this.nmCrosshairLineLength);
+            this.groupBox8.Controls.Add(this.label40);
+            this.groupBox8.Controls.Add(this.label36);
+            this.groupBox8.Controls.Add(this.label41);
+            this.groupBox8.Controls.Add(this.label39);
+            this.groupBox8.Controls.Add(this.nmCrosshairLineMargin);
+            this.groupBox8.Location = new System.Drawing.Point(5, 375);
+            this.groupBox8.Name = "groupBox8";
+            this.groupBox8.Size = new System.Drawing.Size(605, 102);
+            this.groupBox8.TabIndex = 55;
+            this.groupBox8.TabStop = false;
+            this.groupBox8.Text = "Crosshairs";
+            // 
+            // label44
+            // 
+            this.label44.AutoSize = true;
+            this.label44.Location = new System.Drawing.Point(4, 67);
+            this.label44.Name = "label44";
+            this.label44.Size = new System.Drawing.Size(156, 18);
+            this.label44.TabIndex = 61;
+            this.label44.Text = "Crosshairs Fade After:";
+            // 
+            // cbCrosshairShowOnlyOnSelectedIssues
+            // 
+            this.cbCrosshairShowOnlyOnSelectedIssues.AutoSize = true;
+            this.cbCrosshairShowOnlyOnSelectedIssues.Location = new System.Drawing.Point(7, 30);
+            this.cbCrosshairShowOnlyOnSelectedIssues.Name = "cbCrosshairShowOnlyOnSelectedIssues";
+            this.cbCrosshairShowOnlyOnSelectedIssues.Size = new System.Drawing.Size(306, 22);
+            this.cbCrosshairShowOnlyOnSelectedIssues.TabIndex = 53;
+            this.cbCrosshairShowOnlyOnSelectedIssues.Text = "Show Crosshairs for Selected Issues Only";
+            this.toolTip.SetToolTip(this.cbCrosshairShowOnlyOnSelectedIssues, "Determines weather crosshairs are displayed for all issue, or only selected issue" +
+        "s.");
+            this.cbCrosshairShowOnlyOnSelectedIssues.UseVisualStyleBackColor = true;
+            // 
+            // cbCrosshairFadeLevel
+            // 
+            this.cbCrosshairFadeLevel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.cbCrosshairFadeLevel.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cbCrosshairFadeLevel.FormattingEnabled = true;
+            this.cbCrosshairFadeLevel.Location = new System.Drawing.Point(166, 64);
+            this.cbCrosshairFadeLevel.Name = "cbCrosshairFadeLevel";
+            this.cbCrosshairFadeLevel.Size = new System.Drawing.Size(68, 26);
+            this.cbCrosshairFadeLevel.TabIndex = 54;
+            this.toolTip.SetToolTip(this.cbCrosshairFadeLevel, "Determines the zoom factor after which the crosshairs will automatically be hidde" +
+        "n.");
+            // 
+            // nmCrosshairLineLength
+            // 
+            this.nmCrosshairLineLength.Location = new System.Drawing.Point(519, 34);
+            this.nmCrosshairLineLength.Maximum = new decimal(new int[] {
+            1000000,
+            0,
+            0,
+            0});
+            this.nmCrosshairLineLength.Name = "nmCrosshairLineLength";
+            this.nmCrosshairLineLength.Size = new System.Drawing.Size(57, 24);
+            this.nmCrosshairLineLength.TabIndex = 55;
+            this.toolTip.SetToolTip(this.nmCrosshairLineLength, "Length of the crosshair line in pixels.  Setting this value to 0 will use the ful" +
+        "l lenght and height of the layer.");
             // 
             // label40
             // 
             this.label40.AutoSize = true;
-            this.label40.Location = new System.Drawing.Point(226, 422);
+            this.label40.Location = new System.Drawing.Point(577, 67);
             this.label40.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label40.Name = "label40";
             this.label40.Size = new System.Drawing.Size(23, 18);
-            this.label40.TabIndex = 48;
+            this.label40.TabIndex = 60;
             this.label40.Text = "px";
+            // 
+            // label36
+            // 
+            this.label36.AutoSize = true;
+            this.label36.Location = new System.Drawing.Point(368, 38);
+            this.label36.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label36.Name = "label36";
+            this.label36.Size = new System.Drawing.Size(110, 18);
+            this.label36.TabIndex = 57;
+            this.label36.Text = "Crosshair Size:";
             // 
             // label41
             // 
             this.label41.AutoSize = true;
-            this.label41.Location = new System.Drawing.Point(9, 422);
+            this.label41.Location = new System.Drawing.Point(368, 68);
             this.label41.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label41.Name = "label41";
             this.label41.Size = new System.Drawing.Size(126, 18);
-            this.label41.TabIndex = 47;
-            this.label41.Text = "Crosshair margin:";
+            this.label41.TabIndex = 59;
+            this.label41.Text = "Crosshair Margin:";
+            // 
+            // label39
+            // 
+            this.label39.AutoSize = true;
+            this.label39.Location = new System.Drawing.Point(577, 34);
+            this.label39.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label39.Name = "label39";
+            this.label39.Size = new System.Drawing.Size(23, 18);
+            this.label39.TabIndex = 58;
+            this.label39.Text = "px";
             // 
             // nmCrosshairLineMargin
             // 
-            this.nmCrosshairLineMargin.Location = new System.Drawing.Point(162, 419);
+            this.nmCrosshairLineMargin.Location = new System.Drawing.Point(519, 64);
             this.nmCrosshairLineMargin.Maximum = new decimal(new int[] {
             255,
             0,
@@ -1454,104 +1656,47 @@
             0});
             this.nmCrosshairLineMargin.Name = "nmCrosshairLineMargin";
             this.nmCrosshairLineMargin.Size = new System.Drawing.Size(57, 24);
-            this.nmCrosshairLineMargin.TabIndex = 46;
+            this.nmCrosshairLineMargin.TabIndex = 56;
+            this.toolTip.SetToolTip(this.nmCrosshairLineMargin, "Determines the margin between the end of the crosshair, and the bounding rectangl" +
+        "e of an issue.");
             this.nmCrosshairLineMargin.Value = new decimal(new int[] {
             1,
             0,
             0,
             0});
             // 
-            // label39
+            // groupBox9
             // 
-            this.label39.AutoSize = true;
-            this.label39.Location = new System.Drawing.Point(226, 392);
-            this.label39.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label39.Name = "label39";
-            this.label39.Size = new System.Drawing.Size(213, 18);
-            this.label39.TabIndex = 45;
-            this.label39.Text = "px (0 to fill up to image bounds)";
+            this.groupBox9.Controls.Add(this.cbLayerAutoRotateBestView);
+            this.groupBox9.Controls.Add(this.cbLayerZoomToFit);
+            this.groupBox9.Location = new System.Drawing.Point(5, 483);
+            this.groupBox9.Name = "groupBox9";
+            this.groupBox9.Size = new System.Drawing.Size(605, 63);
+            this.groupBox9.TabIndex = 56;
+            this.groupBox9.TabStop = false;
+            this.groupBox9.Text = "Miscellaneous";
             // 
-            // label37
+            // cbLayerAutoRotateBestView
             // 
-            this.label37.AutoSize = true;
-            this.label37.Location = new System.Drawing.Point(526, 363);
-            this.label37.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label37.Name = "label37";
-            this.label37.Size = new System.Drawing.Size(47, 18);
-            this.label37.TabIndex = 44;
-            this.label37.Text = "zoom";
+            this.cbLayerAutoRotateBestView.AutoSize = true;
+            this.cbLayerAutoRotateBestView.Location = new System.Drawing.Point(12, 27);
+            this.cbLayerAutoRotateBestView.Name = "cbLayerAutoRotateBestView";
+            this.cbLayerAutoRotateBestView.Size = new System.Drawing.Size(163, 22);
+            this.cbLayerAutoRotateBestView.TabIndex = 2;
+            this.cbLayerAutoRotateBestView.Text = "Auto Rotate on Load";
+            this.toolTip.SetToolTip(this.cbLayerAutoRotateBestView, "Rotate layer for best fit in layer preview when file is loaded.");
+            this.cbLayerAutoRotateBestView.UseVisualStyleBackColor = true;
             // 
-            // label36
+            // cbLayerZoomToFit
             // 
-            this.label36.AutoSize = true;
-            this.label36.Location = new System.Drawing.Point(9, 392);
-            this.label36.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label36.Name = "label36";
-            this.label36.Size = new System.Drawing.Size(146, 18);
-            this.label36.TabIndex = 43;
-            this.label36.Text = "Crosshair line length:";
-            // 
-            // cbCrosshairShowOnlyOnSelectedIssues
-            // 
-            this.cbCrosshairShowOnlyOnSelectedIssues.AutoSize = true;
-            this.cbCrosshairShowOnlyOnSelectedIssues.Location = new System.Drawing.Point(11, 361);
-            this.cbCrosshairShowOnlyOnSelectedIssues.Name = "cbCrosshairShowOnlyOnSelectedIssues";
-            this.cbCrosshairShowOnlyOnSelectedIssues.Size = new System.Drawing.Size(434, 22);
-            this.cbCrosshairShowOnlyOnSelectedIssues.TabIndex = 42;
-            this.cbCrosshairShowOnlyOnSelectedIssues.Text = "Show crossharis only for the selected issues. Hide them after:";
-            this.cbCrosshairShowOnlyOnSelectedIssues.UseVisualStyleBackColor = true;
-            // 
-            // label38
-            // 
-            this.label38.AutoSize = true;
-            this.label38.Location = new System.Drawing.Point(393, 307);
-            this.label38.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label38.Name = "label38";
-            this.label38.Size = new System.Drawing.Size(47, 18);
-            this.label38.TabIndex = 41;
-            this.label38.Text = "zoom";
-            // 
-            // nmCrosshairLineLength
-            // 
-            this.nmCrosshairLineLength.Location = new System.Drawing.Point(162, 389);
-            this.nmCrosshairLineLength.Maximum = new decimal(new int[] {
-            1000000,
-            0,
-            0,
-            0});
-            this.nmCrosshairLineLength.Name = "nmCrosshairLineLength";
-            this.nmCrosshairLineLength.Size = new System.Drawing.Size(57, 24);
-            this.nmCrosshairLineLength.TabIndex = 40;
-            // 
-            // cbCrosshairFadeLevel
-            // 
-            this.cbCrosshairFadeLevel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.cbCrosshairFadeLevel.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cbCrosshairFadeLevel.FormattingEnabled = true;
-            this.cbCrosshairFadeLevel.Location = new System.Drawing.Point(451, 359);
-            this.cbCrosshairFadeLevel.Name = "cbCrosshairFadeLevel";
-            this.cbCrosshairFadeLevel.Size = new System.Drawing.Size(68, 26);
-            this.cbCrosshairFadeLevel.TabIndex = 37;
-            // 
-            // cbZoomIssues
-            // 
-            this.cbZoomIssues.AutoSize = true;
-            this.cbZoomIssues.Location = new System.Drawing.Point(11, 305);
-            this.cbZoomIssues.Name = "cbZoomIssues";
-            this.cbZoomIssues.Size = new System.Drawing.Size(301, 22);
-            this.cbZoomIssues.TabIndex = 35;
-            this.cbZoomIssues.Text = "Zoom to issues and drawings region with:";
-            this.cbZoomIssues.UseVisualStyleBackColor = true;
-            // 
-            // cbZoomLockLevel
-            // 
-            this.cbZoomLockLevel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.cbZoomLockLevel.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cbZoomLockLevel.FormattingEnabled = true;
-            this.cbZoomLockLevel.Location = new System.Drawing.Point(318, 303);
-            this.cbZoomLockLevel.Name = "cbZoomLockLevel";
-            this.cbZoomLockLevel.Size = new System.Drawing.Size(68, 26);
-            this.cbZoomLockLevel.TabIndex = 36;
+            this.cbLayerZoomToFit.AutoSize = true;
+            this.cbLayerZoomToFit.Location = new System.Drawing.Point(217, 27);
+            this.cbLayerZoomToFit.Name = "cbLayerZoomToFit";
+            this.cbLayerZoomToFit.Size = new System.Drawing.Size(162, 22);
+            this.cbLayerZoomToFit.TabIndex = 3;
+            this.cbLayerZoomToFit.Text = "Zoom to Fit on Load";
+            this.toolTip.SetToolTip(this.cbLayerZoomToFit, "Zoom layer to fit layer preview when file is loaded.");
+            this.cbLayerZoomToFit.UseVisualStyleBackColor = true;
             // 
             // tabPage3
             // 
@@ -1561,44 +1706,43 @@
             this.tabPage3.Location = new System.Drawing.Point(4, 27);
             this.tabPage3.Name = "tabPage3";
             this.tabPage3.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage3.Size = new System.Drawing.Size(616, 594);
+            this.tabPage3.Size = new System.Drawing.Size(616, 630);
             this.tabPage3.TabIndex = 2;
             this.tabPage3.Text = "Issues";
             this.tabPage3.UseVisualStyleBackColor = true;
             // 
             // tabPage4
             // 
+            this.tabPage4.Controls.Add(this.groupBox10);
             this.tabPage4.Controls.Add(this.cbPartialUpdateIslandsOnEditing);
-            this.tabPage4.Controls.Add(this.btnPixelEditorDrainHoleColor);
-            this.tabPage4.Controls.Add(this.btnPixelEditorDrainHoleHLColor);
-            this.tabPage4.Controls.Add(this.label26);
-            this.tabPage4.Controls.Add(this.btnPixelEditorSupportColor);
-            this.tabPage4.Controls.Add(this.btnPixelEditorSupportHLColor);
-            this.tabPage4.Controls.Add(this.label25);
-            this.tabPage4.Controls.Add(this.btnPixelEditorRemovePixelColor);
-            this.tabPage4.Controls.Add(this.btnPixelEditorRemovePixelHLColor);
-            this.tabPage4.Controls.Add(this.label24);
-            this.tabPage4.Controls.Add(this.label23);
-            this.tabPage4.Controls.Add(this.btnPixelEditorAddPixelColor);
-            this.tabPage4.Controls.Add(this.btnPixelEditorAddPixelHLColor);
             this.tabPage4.Location = new System.Drawing.Point(4, 27);
             this.tabPage4.Name = "tabPage4";
             this.tabPage4.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage4.Size = new System.Drawing.Size(616, 594);
+            this.tabPage4.Size = new System.Drawing.Size(616, 630);
             this.tabPage4.TabIndex = 3;
             this.tabPage4.Text = "Pixel Editor";
             this.tabPage4.UseVisualStyleBackColor = true;
             // 
-            // cbPartialUpdateIslandsOnEditing
+            // groupBox10
             // 
-            this.cbPartialUpdateIslandsOnEditing.AutoSize = true;
-            this.cbPartialUpdateIslandsOnEditing.Location = new System.Drawing.Point(9, 170);
-            this.cbPartialUpdateIslandsOnEditing.Name = "cbPartialUpdateIslandsOnEditing";
-            this.cbPartialUpdateIslandsOnEditing.Size = new System.Drawing.Size(565, 40);
-            this.cbPartialUpdateIslandsOnEditing.TabIndex = 19;
-            this.cbPartialUpdateIslandsOnEditing.Text = "Partial update islands for the affected layers after apply the modifications and " +
-    "when\r\nremove a island";
-            this.cbPartialUpdateIslandsOnEditing.UseVisualStyleBackColor = true;
+            this.groupBox10.Controls.Add(this.btnPixelEditorDrainHoleColor);
+            this.groupBox10.Controls.Add(this.btnPixelEditorDrainHoleHLColor);
+            this.groupBox10.Controls.Add(this.label26);
+            this.groupBox10.Controls.Add(this.btnPixelEditorSupportColor);
+            this.groupBox10.Controls.Add(this.btnPixelEditorSupportHLColor);
+            this.groupBox10.Controls.Add(this.label25);
+            this.groupBox10.Controls.Add(this.btnPixelEditorRemovePixelColor);
+            this.groupBox10.Controls.Add(this.btnPixelEditorRemovePixelHLColor);
+            this.groupBox10.Controls.Add(this.label24);
+            this.groupBox10.Controls.Add(this.label23);
+            this.groupBox10.Controls.Add(this.btnPixelEditorAddPixelColor);
+            this.groupBox10.Controls.Add(this.btnPixelEditorAddPixelHLColor);
+            this.groupBox10.Location = new System.Drawing.Point(0, 6);
+            this.groupBox10.Name = "groupBox10";
+            this.groupBox10.Size = new System.Drawing.Size(616, 162);
+            this.groupBox10.TabIndex = 24;
+            this.groupBox10.TabStop = false;
+            this.groupBox10.Text = "Pixel Editor Colors";
             // 
             // btnPixelEditorDrainHoleColor
             // 
@@ -1606,11 +1750,12 @@
             this.btnPixelEditorDrainHoleColor.FlatAppearance.BorderColor = System.Drawing.Color.Black;
             this.btnPixelEditorDrainHoleColor.FlatAppearance.BorderSize = 2;
             this.btnPixelEditorDrainHoleColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnPixelEditorDrainHoleColor.Location = new System.Drawing.Point(256, 131);
+            this.btnPixelEditorDrainHoleColor.Location = new System.Drawing.Point(420, 122);
             this.btnPixelEditorDrainHoleColor.Margin = new System.Windows.Forms.Padding(4);
             this.btnPixelEditorDrainHoleColor.Name = "btnPixelEditorDrainHoleColor";
-            this.btnPixelEditorDrainHoleColor.Size = new System.Drawing.Size(32, 32);
-            this.btnPixelEditorDrainHoleColor.TabIndex = 9;
+            this.btnPixelEditorDrainHoleColor.Size = new System.Drawing.Size(24, 24);
+            this.btnPixelEditorDrainHoleColor.TabIndex = 31;
+            this.toolTip.SetToolTip(this.btnPixelEditorDrainHoleColor, "Drain hole operations on the layer that are not currently selected.");
             this.btnPixelEditorDrainHoleColor.UseVisualStyleBackColor = false;
             this.btnPixelEditorDrainHoleColor.Click += new System.EventHandler(this.EventClick);
             // 
@@ -1620,23 +1765,25 @@
             this.btnPixelEditorDrainHoleHLColor.FlatAppearance.BorderColor = System.Drawing.Color.Black;
             this.btnPixelEditorDrainHoleHLColor.FlatAppearance.BorderSize = 2;
             this.btnPixelEditorDrainHoleHLColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnPixelEditorDrainHoleHLColor.Location = new System.Drawing.Point(299, 131);
+            this.btnPixelEditorDrainHoleHLColor.Location = new System.Drawing.Point(452, 122);
             this.btnPixelEditorDrainHoleHLColor.Margin = new System.Windows.Forms.Padding(4);
             this.btnPixelEditorDrainHoleHLColor.Name = "btnPixelEditorDrainHoleHLColor";
-            this.btnPixelEditorDrainHoleHLColor.Size = new System.Drawing.Size(32, 32);
-            this.btnPixelEditorDrainHoleHLColor.TabIndex = 23;
+            this.btnPixelEditorDrainHoleHLColor.Size = new System.Drawing.Size(24, 24);
+            this.btnPixelEditorDrainHoleHLColor.TabIndex = 35;
+            this.toolTip.SetToolTip(this.btnPixelEditorDrainHoleHLColor, "Drain Hole operations on the layer that are currently selected in the issue list." +
+        "");
             this.btnPixelEditorDrainHoleHLColor.UseVisualStyleBackColor = false;
             this.btnPixelEditorDrainHoleHLColor.Click += new System.EventHandler(this.EventClick);
             // 
             // label26
             // 
             this.label26.AutoSize = true;
-            this.label26.Location = new System.Drawing.Point(9, 138);
+            this.label26.Location = new System.Drawing.Point(8, 124);
             this.label26.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label26.Name = "label26";
-            this.label26.Size = new System.Drawing.Size(223, 18);
-            this.label26.TabIndex = 8;
-            this.label26.Text = "Drain hole color / Highlight color:";
+            this.label26.Size = new System.Drawing.Size(363, 18);
+            this.label26.TabIndex = 30;
+            this.label26.Text = "Drain Hole Operation / Selected Drain Hole Operation:";
             // 
             // btnPixelEditorSupportColor
             // 
@@ -1644,11 +1791,12 @@
             this.btnPixelEditorSupportColor.FlatAppearance.BorderColor = System.Drawing.Color.Black;
             this.btnPixelEditorSupportColor.FlatAppearance.BorderSize = 2;
             this.btnPixelEditorSupportColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnPixelEditorSupportColor.Location = new System.Drawing.Point(256, 91);
+            this.btnPixelEditorSupportColor.Location = new System.Drawing.Point(420, 90);
             this.btnPixelEditorSupportColor.Margin = new System.Windows.Forms.Padding(4);
             this.btnPixelEditorSupportColor.Name = "btnPixelEditorSupportColor";
-            this.btnPixelEditorSupportColor.Size = new System.Drawing.Size(32, 32);
-            this.btnPixelEditorSupportColor.TabIndex = 7;
+            this.btnPixelEditorSupportColor.Size = new System.Drawing.Size(24, 24);
+            this.btnPixelEditorSupportColor.TabIndex = 29;
+            this.toolTip.SetToolTip(this.btnPixelEditorSupportColor, "Support operations on the layer that are not currently selected.");
             this.btnPixelEditorSupportColor.UseVisualStyleBackColor = false;
             this.btnPixelEditorSupportColor.Click += new System.EventHandler(this.EventClick);
             // 
@@ -1658,23 +1806,24 @@
             this.btnPixelEditorSupportHLColor.FlatAppearance.BorderColor = System.Drawing.Color.Black;
             this.btnPixelEditorSupportHLColor.FlatAppearance.BorderSize = 2;
             this.btnPixelEditorSupportHLColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnPixelEditorSupportHLColor.Location = new System.Drawing.Point(299, 91);
+            this.btnPixelEditorSupportHLColor.Location = new System.Drawing.Point(452, 90);
             this.btnPixelEditorSupportHLColor.Margin = new System.Windows.Forms.Padding(4);
             this.btnPixelEditorSupportHLColor.Name = "btnPixelEditorSupportHLColor";
-            this.btnPixelEditorSupportHLColor.Size = new System.Drawing.Size(32, 32);
-            this.btnPixelEditorSupportHLColor.TabIndex = 22;
+            this.btnPixelEditorSupportHLColor.Size = new System.Drawing.Size(24, 24);
+            this.btnPixelEditorSupportHLColor.TabIndex = 34;
+            this.toolTip.SetToolTip(this.btnPixelEditorSupportHLColor, "Support operations on the layer that are currently selected in the issue list.");
             this.btnPixelEditorSupportHLColor.UseVisualStyleBackColor = false;
             this.btnPixelEditorSupportHLColor.Click += new System.EventHandler(this.EventClick);
             // 
             // label25
             // 
             this.label25.AutoSize = true;
-            this.label25.Location = new System.Drawing.Point(9, 98);
+            this.label25.Location = new System.Drawing.Point(8, 92);
             this.label25.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label25.Name = "label25";
-            this.label25.Size = new System.Drawing.Size(208, 18);
-            this.label25.TabIndex = 6;
-            this.label25.Text = "Support color / Highlight color:";
+            this.label25.Size = new System.Drawing.Size(327, 18);
+            this.label25.TabIndex = 28;
+            this.label25.Text = "Support Operation / Selected Support Operation:";
             // 
             // btnPixelEditorRemovePixelColor
             // 
@@ -1682,11 +1831,12 @@
             this.btnPixelEditorRemovePixelColor.FlatAppearance.BorderColor = System.Drawing.Color.Black;
             this.btnPixelEditorRemovePixelColor.FlatAppearance.BorderSize = 2;
             this.btnPixelEditorRemovePixelColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnPixelEditorRemovePixelColor.Location = new System.Drawing.Point(256, 51);
+            this.btnPixelEditorRemovePixelColor.Location = new System.Drawing.Point(420, 58);
             this.btnPixelEditorRemovePixelColor.Margin = new System.Windows.Forms.Padding(4);
             this.btnPixelEditorRemovePixelColor.Name = "btnPixelEditorRemovePixelColor";
-            this.btnPixelEditorRemovePixelColor.Size = new System.Drawing.Size(32, 32);
-            this.btnPixelEditorRemovePixelColor.TabIndex = 5;
+            this.btnPixelEditorRemovePixelColor.Size = new System.Drawing.Size(24, 24);
+            this.btnPixelEditorRemovePixelColor.TabIndex = 27;
+            this.toolTip.SetToolTip(this.btnPixelEditorRemovePixelColor, "Pixel remove operations on the layer that are not currently selected.");
             this.btnPixelEditorRemovePixelColor.UseVisualStyleBackColor = false;
             this.btnPixelEditorRemovePixelColor.Click += new System.EventHandler(this.EventClick);
             // 
@@ -1696,33 +1846,35 @@
             this.btnPixelEditorRemovePixelHLColor.FlatAppearance.BorderColor = System.Drawing.Color.Black;
             this.btnPixelEditorRemovePixelHLColor.FlatAppearance.BorderSize = 2;
             this.btnPixelEditorRemovePixelHLColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnPixelEditorRemovePixelHLColor.Location = new System.Drawing.Point(298, 51);
+            this.btnPixelEditorRemovePixelHLColor.Location = new System.Drawing.Point(452, 58);
             this.btnPixelEditorRemovePixelHLColor.Margin = new System.Windows.Forms.Padding(4);
             this.btnPixelEditorRemovePixelHLColor.Name = "btnPixelEditorRemovePixelHLColor";
-            this.btnPixelEditorRemovePixelHLColor.Size = new System.Drawing.Size(32, 32);
-            this.btnPixelEditorRemovePixelHLColor.TabIndex = 21;
+            this.btnPixelEditorRemovePixelHLColor.Size = new System.Drawing.Size(24, 24);
+            this.btnPixelEditorRemovePixelHLColor.TabIndex = 33;
+            this.toolTip.SetToolTip(this.btnPixelEditorRemovePixelHLColor, "Pixel remove operations on the layer that are currently selected in the issue lis" +
+        "t.");
             this.btnPixelEditorRemovePixelHLColor.UseVisualStyleBackColor = false;
             this.btnPixelEditorRemovePixelHLColor.Click += new System.EventHandler(this.EventClick);
             // 
             // label24
             // 
             this.label24.AutoSize = true;
-            this.label24.Location = new System.Drawing.Point(9, 58);
+            this.label24.Location = new System.Drawing.Point(8, 60);
             this.label24.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label24.Name = "label24";
-            this.label24.Size = new System.Drawing.Size(241, 18);
-            this.label24.TabIndex = 4;
-            this.label24.Text = "Pixel remove color / Highlight color:";
+            this.label24.Size = new System.Drawing.Size(405, 18);
+            this.label24.TabIndex = 26;
+            this.label24.Text = "Pixel Remove Operation / Selected Pixel Remove Operation:";
             // 
             // label23
             // 
             this.label23.AutoSize = true;
-            this.label23.Location = new System.Drawing.Point(9, 17);
+            this.label23.Location = new System.Drawing.Point(8, 30);
             this.label23.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label23.Name = "label23";
-            this.label23.Size = new System.Drawing.Size(215, 18);
-            this.label23.TabIndex = 2;
-            this.label23.Text = "Pixel add color / Highlight color:";
+            this.label23.Size = new System.Drawing.Size(343, 18);
+            this.label23.TabIndex = 24;
+            this.label23.Text = "Pixel Add Operation / Selected Pixel Add Operation:";
             // 
             // btnPixelEditorAddPixelColor
             // 
@@ -1730,11 +1882,12 @@
             this.btnPixelEditorAddPixelColor.FlatAppearance.BorderColor = System.Drawing.Color.Black;
             this.btnPixelEditorAddPixelColor.FlatAppearance.BorderSize = 2;
             this.btnPixelEditorAddPixelColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnPixelEditorAddPixelColor.Location = new System.Drawing.Point(256, 10);
+            this.btnPixelEditorAddPixelColor.Location = new System.Drawing.Point(420, 26);
             this.btnPixelEditorAddPixelColor.Margin = new System.Windows.Forms.Padding(4);
             this.btnPixelEditorAddPixelColor.Name = "btnPixelEditorAddPixelColor";
-            this.btnPixelEditorAddPixelColor.Size = new System.Drawing.Size(32, 32);
-            this.btnPixelEditorAddPixelColor.TabIndex = 3;
+            this.btnPixelEditorAddPixelColor.Size = new System.Drawing.Size(24, 24);
+            this.btnPixelEditorAddPixelColor.TabIndex = 25;
+            this.toolTip.SetToolTip(this.btnPixelEditorAddPixelColor, "Pixel add operations on the layer that are not currently selected.");
             this.btnPixelEditorAddPixelColor.UseVisualStyleBackColor = false;
             this.btnPixelEditorAddPixelColor.Click += new System.EventHandler(this.EventClick);
             // 
@@ -1744,13 +1897,26 @@
             this.btnPixelEditorAddPixelHLColor.FlatAppearance.BorderColor = System.Drawing.Color.Black;
             this.btnPixelEditorAddPixelHLColor.FlatAppearance.BorderSize = 2;
             this.btnPixelEditorAddPixelHLColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnPixelEditorAddPixelHLColor.Location = new System.Drawing.Point(298, 10);
+            this.btnPixelEditorAddPixelHLColor.Location = new System.Drawing.Point(452, 26);
             this.btnPixelEditorAddPixelHLColor.Margin = new System.Windows.Forms.Padding(4);
             this.btnPixelEditorAddPixelHLColor.Name = "btnPixelEditorAddPixelHLColor";
-            this.btnPixelEditorAddPixelHLColor.Size = new System.Drawing.Size(32, 32);
-            this.btnPixelEditorAddPixelHLColor.TabIndex = 20;
+            this.btnPixelEditorAddPixelHLColor.Size = new System.Drawing.Size(24, 24);
+            this.btnPixelEditorAddPixelHLColor.TabIndex = 32;
+            this.toolTip.SetToolTip(this.btnPixelEditorAddPixelHLColor, "Pixel add operations on the layer that are currently selected in the issue list.");
             this.btnPixelEditorAddPixelHLColor.UseVisualStyleBackColor = false;
             this.btnPixelEditorAddPixelHLColor.Click += new System.EventHandler(this.EventClick);
+            // 
+            // cbPartialUpdateIslandsOnEditing
+            // 
+            this.cbPartialUpdateIslandsOnEditing.AutoSize = true;
+            this.cbPartialUpdateIslandsOnEditing.Location = new System.Drawing.Point(11, 185);
+            this.cbPartialUpdateIslandsOnEditing.Name = "cbPartialUpdateIslandsOnEditing";
+            this.cbPartialUpdateIslandsOnEditing.Size = new System.Drawing.Size(256, 22);
+            this.cbPartialUpdateIslandsOnEditing.TabIndex = 19;
+            this.cbPartialUpdateIslandsOnEditing.Text = "Refresh Issues for Modified Layers";
+            this.toolTip.SetToolTip(this.cbPartialUpdateIslandsOnEditing, "If checked, when edit settings are applied, modified layers will be analyzed for " +
+        "new or removed islands and the issue list will be updated accordingly.");
+            this.cbPartialUpdateIslandsOnEditing.UseVisualStyleBackColor = true;
             // 
             // tabPage5
             // 
@@ -1766,14 +1932,14 @@
             this.tabPage5.Location = new System.Drawing.Point(4, 27);
             this.tabPage5.Name = "tabPage5";
             this.tabPage5.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage5.Size = new System.Drawing.Size(616, 594);
+            this.tabPage5.Size = new System.Drawing.Size(616, 630);
             this.tabPage5.TabIndex = 4;
             this.tabPage5.Text = "Layer Repair";
             this.tabPage5.UseVisualStyleBackColor = true;
             // 
             // nmLayerRepairRemoveIslandsBelowEqualPixelsDefault
             // 
-            this.nmLayerRepairRemoveIslandsBelowEqualPixelsDefault.Location = new System.Drawing.Point(6, 66);
+            this.nmLayerRepairRemoveIslandsBelowEqualPixelsDefault.Location = new System.Drawing.Point(12, 83);
             this.nmLayerRepairRemoveIslandsBelowEqualPixelsDefault.Maximum = new decimal(new int[] {
             255,
             0,
@@ -1782,6 +1948,9 @@
             this.nmLayerRepairRemoveIslandsBelowEqualPixelsDefault.Name = "nmLayerRepairRemoveIslandsBelowEqualPixelsDefault";
             this.nmLayerRepairRemoveIslandsBelowEqualPixelsDefault.Size = new System.Drawing.Size(57, 24);
             this.nmLayerRepairRemoveIslandsBelowEqualPixelsDefault.TabIndex = 34;
+            this.toolTip.SetToolTip(this.nmLayerRepairRemoveIslandsBelowEqualPixelsDefault, "Deafult setting for the maximum area of islands that will be automatically remove" +
+        "d by the issue repair algorithm.  Islands larger than this area will not be remo" +
+        "ved.");
             this.nmLayerRepairRemoveIslandsBelowEqualPixelsDefault.Value = new decimal(new int[] {
             1,
             0,
@@ -1791,15 +1960,15 @@
             // label35
             // 
             this.label35.AutoSize = true;
-            this.label35.Location = new System.Drawing.Point(69, 69);
+            this.label35.Location = new System.Drawing.Point(75, 86);
             this.label35.Name = "label35";
-            this.label35.Size = new System.Drawing.Size(357, 18);
+            this.label35.Size = new System.Drawing.Size(250, 18);
             this.label35.TabIndex = 35;
-            this.label35.Text = "Remove islands below or equal to pixels default value";
+            this.label35.Text = "Default Pixel Area for Island Removal";
             // 
             // nmLayerRepairDefaultOpeningIterations
             // 
-            this.nmLayerRepairDefaultOpeningIterations.Location = new System.Drawing.Point(6, 36);
+            this.nmLayerRepairDefaultOpeningIterations.Location = new System.Drawing.Point(12, 49);
             this.nmLayerRepairDefaultOpeningIterations.Maximum = new decimal(new int[] {
             255,
             0,
@@ -1808,6 +1977,7 @@
             this.nmLayerRepairDefaultOpeningIterations.Name = "nmLayerRepairDefaultOpeningIterations";
             this.nmLayerRepairDefaultOpeningIterations.Size = new System.Drawing.Size(57, 24);
             this.nmLayerRepairDefaultOpeningIterations.TabIndex = 32;
+            this.toolTip.SetToolTip(this.nmLayerRepairDefaultOpeningIterations, resources.GetString("nmLayerRepairDefaultOpeningIterations.ToolTip"));
             this.nmLayerRepairDefaultOpeningIterations.Value = new decimal(new int[] {
             1,
             0,
@@ -1817,15 +1987,15 @@
             // label34
             // 
             this.label34.AutoSize = true;
-            this.label34.Location = new System.Drawing.Point(69, 39);
+            this.label34.Location = new System.Drawing.Point(75, 52);
             this.label34.Name = "label34";
-            this.label34.Size = new System.Drawing.Size(215, 18);
+            this.label34.Size = new System.Drawing.Size(224, 18);
             this.label34.TabIndex = 33;
-            this.label34.Text = "Noise removal default iterations";
+            this.label34.Text = "Default Noise Removal Iterations";
             // 
             // nmLayerRepairDefaultClosingIterations
             // 
-            this.nmLayerRepairDefaultClosingIterations.Location = new System.Drawing.Point(6, 6);
+            this.nmLayerRepairDefaultClosingIterations.Location = new System.Drawing.Point(12, 15);
             this.nmLayerRepairDefaultClosingIterations.Maximum = new decimal(new int[] {
             255,
             0,
@@ -1834,6 +2004,8 @@
             this.nmLayerRepairDefaultClosingIterations.Name = "nmLayerRepairDefaultClosingIterations";
             this.nmLayerRepairDefaultClosingIterations.Size = new System.Drawing.Size(57, 24);
             this.nmLayerRepairDefaultClosingIterations.TabIndex = 30;
+            this.toolTip.SetToolTip(this.nmLayerRepairDefaultClosingIterations, "Default number of iterations the repair algorithm will apply in an attempt to fin" +
+        "d nearby pixels to attach an isaland to.");
             this.nmLayerRepairDefaultClosingIterations.Value = new decimal(new int[] {
             1,
             0,
@@ -1843,40 +2015,40 @@
             // label33
             // 
             this.label33.AutoSize = true;
-            this.label33.Location = new System.Drawing.Point(69, 9);
+            this.label33.Location = new System.Drawing.Point(75, 18);
             this.label33.Name = "label33";
-            this.label33.Size = new System.Drawing.Size(198, 18);
+            this.label33.Size = new System.Drawing.Size(204, 18);
             this.label33.TabIndex = 31;
-            this.label33.Text = "Gap closing default iterations";
+            this.label33.Text = "Default Gap Closing Iterations";
             // 
             // cbLayerRepairResinTraps
             // 
             this.cbLayerRepairResinTraps.AutoSize = true;
-            this.cbLayerRepairResinTraps.Location = new System.Drawing.Point(6, 152);
+            this.cbLayerRepairResinTraps.Location = new System.Drawing.Point(12, 178);
             this.cbLayerRepairResinTraps.Name = "cbLayerRepairResinTraps";
-            this.cbLayerRepairResinTraps.Size = new System.Drawing.Size(209, 22);
+            this.cbLayerRepairResinTraps.Size = new System.Drawing.Size(294, 22);
             this.cbLayerRepairResinTraps.TabIndex = 17;
-            this.cbLayerRepairResinTraps.Text = "Repair resin traps by default";
+            this.cbLayerRepairResinTraps.Text = "Attempt to Repair Resin Traps by Default";
             this.cbLayerRepairResinTraps.UseVisualStyleBackColor = true;
             // 
             // cbLayerRepairRemoveEmptyLayers
             // 
             this.cbLayerRepairRemoveEmptyLayers.AutoSize = true;
-            this.cbLayerRepairRemoveEmptyLayers.Location = new System.Drawing.Point(6, 124);
+            this.cbLayerRepairRemoveEmptyLayers.Location = new System.Drawing.Point(12, 150);
             this.cbLayerRepairRemoveEmptyLayers.Name = "cbLayerRepairRemoveEmptyLayers";
-            this.cbLayerRepairRemoveEmptyLayers.Size = new System.Drawing.Size(236, 22);
+            this.cbLayerRepairRemoveEmptyLayers.Size = new System.Drawing.Size(246, 22);
             this.cbLayerRepairRemoveEmptyLayers.TabIndex = 16;
-            this.cbLayerRepairRemoveEmptyLayers.Text = "Remove empty layers by default";
+            this.cbLayerRepairRemoveEmptyLayers.Text = "Remove Empty Layers by Default";
             this.cbLayerRepairRemoveEmptyLayers.UseVisualStyleBackColor = true;
             // 
             // cbLayerRepairLayersIslands
             // 
             this.cbLayerRepairLayersIslands.AutoSize = true;
-            this.cbLayerRepairLayersIslands.Location = new System.Drawing.Point(6, 96);
+            this.cbLayerRepairLayersIslands.Location = new System.Drawing.Point(12, 122);
             this.cbLayerRepairLayersIslands.Name = "cbLayerRepairLayersIslands";
-            this.cbLayerRepairLayersIslands.Size = new System.Drawing.Size(257, 22);
+            this.cbLayerRepairLayersIslands.Size = new System.Drawing.Size(260, 22);
             this.cbLayerRepairLayersIslands.TabIndex = 15;
-            this.cbLayerRepairLayersIslands.Text = "Repair layers and islands by default";
+            this.cbLayerRepairLayersIslands.Text = "Attempt to Repair Islands by Default";
             this.cbLayerRepairLayersIslands.UseVisualStyleBackColor = true;
             // 
             // panel1
@@ -1885,7 +2057,7 @@
             this.panel1.Controls.Add(this.btnSave);
             this.panel1.Controls.Add(this.btnReset);
             this.panel1.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.panel1.Location = new System.Drawing.Point(0, 548);
+            this.panel1.Location = new System.Drawing.Point(0, 584);
             this.panel1.Name = "panel1";
             this.panel1.Size = new System.Drawing.Size(624, 77);
             this.panel1.TabIndex = 19;
@@ -1898,21 +2070,11 @@
             this.toolTip.ToolTipIcon = System.Windows.Forms.ToolTipIcon.Info;
             this.toolTip.ToolTipTitle = "Information";
             // 
-            // cbComputeEmptyLayers
-            // 
-            this.cbComputeEmptyLayers.AutoSize = true;
-            this.cbComputeEmptyLayers.Location = new System.Drawing.Point(419, 79);
-            this.cbComputeEmptyLayers.Name = "cbComputeEmptyLayers";
-            this.cbComputeEmptyLayers.Size = new System.Drawing.Size(117, 22);
-            this.cbComputeEmptyLayers.TabIndex = 21;
-            this.cbComputeEmptyLayers.Text = "Empty Layers";
-            this.cbComputeEmptyLayers.UseVisualStyleBackColor = true;
-            // 
             // FrmSettings
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 18F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(624, 625);
+            this.ClientSize = new System.Drawing.Size(624, 661);
             this.Controls.Add(this.panel1);
             this.Controls.Add(this.tabSettings);
             this.Font = new System.Drawing.Font("Microsoft Sans Serif", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
@@ -1925,9 +2087,6 @@
             this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Settings";
-            ((System.ComponentModel.ISupportInitialize)(this.nmOutlineHollowAreasLineThickness)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nmOutlineLayerBoundsLineThickness)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nmOutlinePrintVolumeBoundsLineThickness)).EndInit();
             this.groupBox3.ResumeLayout(false);
             this.groupBox3.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nmResinTrapBinaryThreshold)).EndInit();
@@ -1945,17 +2104,29 @@
             this.groupBox1.PerformLayout();
             this.tabSettings.ResumeLayout(false);
             this.tabPage1.ResumeLayout(false);
-            this.groupBox5.ResumeLayout(false);
-            this.groupBox5.PerformLayout();
             this.groupBox4.ResumeLayout(false);
             this.groupBox4.PerformLayout();
+            this.groupBox5.ResumeLayout(false);
+            this.groupBox5.PerformLayout();
             this.tabPage2.ResumeLayout(false);
-            this.tabPage2.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nmCrosshairLineMargin)).EndInit();
+            this.groupBox6.ResumeLayout(false);
+            this.groupBox6.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.nmOutlineHollowAreasLineThickness)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nmOutlineLayerBoundsLineThickness)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nmOutlinePrintVolumeBoundsLineThickness)).EndInit();
+            this.groupBox7.ResumeLayout(false);
+            this.groupBox7.PerformLayout();
+            this.groupBox8.ResumeLayout(false);
+            this.groupBox8.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nmCrosshairLineLength)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nmCrosshairLineMargin)).EndInit();
+            this.groupBox9.ResumeLayout(false);
+            this.groupBox9.PerformLayout();
             this.tabPage3.ResumeLayout(false);
             this.tabPage4.ResumeLayout(false);
             this.tabPage4.PerformLayout();
+            this.groupBox10.ResumeLayout(false);
+            this.groupBox10.PerformLayout();
             this.tabPage5.ResumeLayout(false);
             this.tabPage5.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nmLayerRepairRemoveIslandsBelowEqualPixelsDefault)).EndInit();
@@ -1967,31 +2138,13 @@
         }
 
         #endregion
-
-        private System.Windows.Forms.Label label1;
-        private System.Windows.Forms.Button btnPreviousNextLayerColor;
         private System.Windows.Forms.ColorDialog colorDialog;
-        private System.Windows.Forms.Button btnPreviousLayerColor;
-        private System.Windows.Forms.Label label2;
-        private System.Windows.Forms.Button btnNextLayerColor;
-        private System.Windows.Forms.Label label3;
-        private System.Windows.Forms.Button btnTouchingBoundsColor;
-        private System.Windows.Forms.Label label4;
-        private System.Windows.Forms.Label label5;
-        private System.Windows.Forms.Label label6;
-        private System.Windows.Forms.Button btnResinTrapColor;
-        private System.Windows.Forms.Button btnResinTrapHLColor;
-        private System.Windows.Forms.Button btnIslandColor;
-        private System.Windows.Forms.Button btnIslandHLColor;
         private System.Windows.Forms.Button btnSave;
         private System.Windows.Forms.Button btnCancel;
         private System.Windows.Forms.CheckBox cbStartMaximized;
         private System.Windows.Forms.CheckBox cbCheckForUpdatesOnStartup;
-        private System.Windows.Forms.CheckBox cbLayerAutoRotateBestView;
         private System.Windows.Forms.Button btnReset;
-        private System.Windows.Forms.CheckBox cbLayerDifferenceDefault;
         private System.Windows.Forms.CheckBox cbComputeIssuesOnLoad;
-        private System.Windows.Forms.CheckBox cbLayerZoomToFit;
         private System.Windows.Forms.CheckBox cbComputeResinTraps;
         private System.Windows.Forms.CheckBox cbComputeIslands;
         private System.Windows.Forms.NumericUpDown nmIslandRequiredAreaToProcessCheck;
@@ -2012,22 +2165,6 @@
         private System.Windows.Forms.NumericUpDown nmResinTrapMaximumPixelBrightnessToDrain;
         private System.Windows.Forms.Label label13;
         private System.Windows.Forms.CheckBox cbAutoComputeIssuesClickOnTab;
-        private System.Windows.Forms.Label label14;
-        private System.Windows.Forms.Button btnOutlinePrintVolumeBoundsColor;
-        private System.Windows.Forms.Label label15;
-        private System.Windows.Forms.NumericUpDown nmOutlinePrintVolumeBoundsLineThickness;
-        private System.Windows.Forms.CheckBox cbOutlinePrintVolumeBounds;
-        private System.Windows.Forms.CheckBox cbOutlineLayerBounds;
-        private System.Windows.Forms.Label label16;
-        private System.Windows.Forms.NumericUpDown nmOutlineLayerBoundsLineThickness;
-        private System.Windows.Forms.Label label17;
-        private System.Windows.Forms.Button btnOutlineLayerBoundsColor;
-        private System.Windows.Forms.CheckBox cbOutlineHollowAreas;
-        private System.Windows.Forms.Label label18;
-        private System.Windows.Forms.NumericUpDown nmOutlineHollowAreasLineThickness;
-        private System.Windows.Forms.Label label19;
-        private System.Windows.Forms.Button btnOutlineHollowAreasColor;
-        private System.Windows.Forms.CheckBox cbZoomToFitPrintVolumeBounds;
         private System.Windows.Forms.NumericUpDown nmResinTrapBinaryThreshold;
         private System.Windows.Forms.Label label20;
         private System.Windows.Forms.NumericUpDown nmIslandBinaryThreshold;
@@ -2037,46 +2174,8 @@
         private System.Windows.Forms.TabPage tabPage2;
         private System.Windows.Forms.Panel panel1;
         private System.Windows.Forms.TabPage tabPage3;
-        private System.Windows.Forms.Label label22;
-        private System.Windows.Forms.ComboBox cbDefaultOpenFileExtension;
         private System.Windows.Forms.TabPage tabPage4;
-        private System.Windows.Forms.Button btnPixelEditorRemovePixelColor;
-        private System.Windows.Forms.Button btnPixelEditorRemovePixelHLColor;
-        private System.Windows.Forms.Label label24;
-        private System.Windows.Forms.Label label23;
-        private System.Windows.Forms.Button btnPixelEditorAddPixelColor;
-        private System.Windows.Forms.Button btnPixelEditorAddPixelHLColor;
-        private System.Windows.Forms.Button btnPixelEditorSupportColor;
-        private System.Windows.Forms.Button btnPixelEditorSupportHLColor;
-        private System.Windows.Forms.Label label25;
-        private System.Windows.Forms.Button btnPixelEditorDrainHoleColor;
-        private System.Windows.Forms.Button btnPixelEditorDrainHoleHLColor;
-        private System.Windows.Forms.Label label26;
-        private System.Windows.Forms.CheckBox cbFileSavePromptOverwrite;
-        private System.Windows.Forms.Label label27;
-        private System.Windows.Forms.Label label28;
-        private System.Windows.Forms.TextBox tbFileSaveNameSuffix;
-        private System.Windows.Forms.TextBox tbFileSaveNamePreffix;
         private System.Windows.Forms.GroupBox groupBox4;
-        private System.Windows.Forms.GroupBox groupBox5;
-        private System.Windows.Forms.Button btnFileOpenDefaultDirectoryClear;
-        private System.Windows.Forms.Button btnFileOpenDefaultDirectorySearch;
-        private System.Windows.Forms.Label label29;
-        private System.Windows.Forms.TextBox tbFileOpenDefaultDirectory;
-        private System.Windows.Forms.Button btnFileSaveDefaultDirectoryClear;
-        private System.Windows.Forms.Button btnFileSaveDefaultDirectorySearch;
-        private System.Windows.Forms.Label label30;
-        private System.Windows.Forms.TextBox tbFileSaveDefaultDirectory;
-        private System.Windows.Forms.Button btnFileConvertDefaultDirectoryClear;
-        private System.Windows.Forms.Button btnFileConvertDefaultDirectorySearch;
-        private System.Windows.Forms.Label label31;
-        private System.Windows.Forms.TextBox tbFileConvertDefaultDirectory;
-        private System.Windows.Forms.Button btnFileExtractDefaultDirectoryClear;
-        private System.Windows.Forms.Button btnFileExtractDefaultDirectorySearch;
-        private System.Windows.Forms.Label label32;
-        private System.Windows.Forms.TextBox tbFileExtractDefaultDirectory;
-        private System.Windows.Forms.CheckBox cbZoomIssues;
-        private System.Windows.Forms.ComboBox cbZoomLockLevel;
         private System.Windows.Forms.TabPage tabPage5;
         private System.Windows.Forms.CheckBox cbLayerRepairLayersIslands;
         private System.Windows.Forms.CheckBox cbLayerRepairRemoveEmptyLayers;
@@ -2090,19 +2189,98 @@
         private System.Windows.Forms.CheckBox cbPartialUpdateIslandsOnEditing;
         private System.Windows.Forms.CheckBox cbIslandAllowDiagonalBonds;
         private System.Windows.Forms.ToolTip toolTip;
-        private System.Windows.Forms.ComboBox cbCrosshairFadeLevel;
-        private System.Windows.Forms.NumericUpDown nmCrosshairLineLength;
-        private System.Windows.Forms.Label label38;
-        private System.Windows.Forms.Label label36;
-        private System.Windows.Forms.CheckBox cbCrosshairShowOnlyOnSelectedIssues;
-        private System.Windows.Forms.Label label37;
-        private System.Windows.Forms.Label label39;
-        private System.Windows.Forms.Label label40;
-        private System.Windows.Forms.Label label41;
-        private System.Windows.Forms.NumericUpDown nmCrosshairLineMargin;
-        private System.Windows.Forms.CheckBox cbZoomIssuesAuto;
         private System.Windows.Forms.Label label42;
         private System.Windows.Forms.CheckBox cbComputeTouchingBounds;
         private System.Windows.Forms.CheckBox cbComputeEmptyLayers;
+        private System.Windows.Forms.GroupBox groupBox6;
+        private System.Windows.Forms.GroupBox groupBox7;
+        private System.Windows.Forms.GroupBox groupBox8;
+        private System.Windows.Forms.GroupBox groupBox9;
+        private System.Windows.Forms.GroupBox groupBox5;
+        private System.Windows.Forms.Button btnFileExtractDefaultDirectoryClear;
+        private System.Windows.Forms.Button btnFileExtractDefaultDirectorySearch;
+        private System.Windows.Forms.Label label32;
+        private System.Windows.Forms.TextBox tbFileExtractDefaultDirectory;
+        private System.Windows.Forms.Button btnFileConvertDefaultDirectoryClear;
+        private System.Windows.Forms.Button btnFileConvertDefaultDirectorySearch;
+        private System.Windows.Forms.Label label31;
+        private System.Windows.Forms.TextBox tbFileConvertDefaultDirectory;
+        private System.Windows.Forms.Button btnFileSaveDefaultDirectoryClear;
+        private System.Windows.Forms.Button btnFileSaveDefaultDirectorySearch;
+        private System.Windows.Forms.Label label30;
+        private System.Windows.Forms.TextBox tbFileSaveDefaultDirectory;
+        private System.Windows.Forms.Button btnFileOpenDefaultDirectoryClear;
+        private System.Windows.Forms.Button btnFileOpenDefaultDirectorySearch;
+        private System.Windows.Forms.Label label29;
+        private System.Windows.Forms.TextBox tbFileOpenDefaultDirectory;
+        private System.Windows.Forms.Label label22;
+        private System.Windows.Forms.ComboBox cbDefaultOpenFileExtension;
+        private System.Windows.Forms.Label label28;
+        private System.Windows.Forms.CheckBox cbFileSavePromptOverwrite;
+        private System.Windows.Forms.TextBox tbFileSaveNameSuffix;
+        private System.Windows.Forms.Label label27;
+        private System.Windows.Forms.TextBox tbFileSaveNamePreffix;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.CheckBox cbOutlineHollowAreas;
+        private System.Windows.Forms.Button btnPreviousNextLayerColor;
+        private System.Windows.Forms.Button btnPreviousLayerColor;
+        private System.Windows.Forms.Label label18;
+        private System.Windows.Forms.Button btnIslandColor;
+        private System.Windows.Forms.Button btnIslandHLColor;
+        private System.Windows.Forms.NumericUpDown nmOutlineHollowAreasLineThickness;
+        private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.CheckBox cbLayerDifferenceDefault;
+        private System.Windows.Forms.Label label19;
+        private System.Windows.Forms.Button btnResinTrapColor;
+        private System.Windows.Forms.Button btnResinTrapHLColor;
+        private System.Windows.Forms.Button btnOutlineHollowAreasColor;
+        private System.Windows.Forms.Button btnNextLayerColor;
+        private System.Windows.Forms.Button btnOutlinePrintVolumeBoundsColor;
+        private System.Windows.Forms.CheckBox cbOutlineLayerBounds;
+        private System.Windows.Forms.Label label6;
+        private System.Windows.Forms.Label label14;
+        private System.Windows.Forms.Label label16;
+        private System.Windows.Forms.Label label4;
+        private System.Windows.Forms.NumericUpDown nmOutlineLayerBoundsLineThickness;
+        private System.Windows.Forms.Label label5;
+        private System.Windows.Forms.Label label15;
+        private System.Windows.Forms.Label label17;
+        private System.Windows.Forms.Button btnTouchingBoundsColor;
+        private System.Windows.Forms.CheckBox cbOutlinePrintVolumeBounds;
+        private System.Windows.Forms.Button btnOutlineLayerBoundsColor;
+        private System.Windows.Forms.Label label37;
+        private System.Windows.Forms.NumericUpDown nmOutlinePrintVolumeBoundsLineThickness;
+        private System.Windows.Forms.Button btnCrosshairColor;
+        private System.Windows.Forms.Label label43;
+        private System.Windows.Forms.ComboBox cbZoomToFit;
+        private System.Windows.Forms.CheckBox cbZoomIssues;
+        private System.Windows.Forms.CheckBox cbZoomIssuesAuto;
+        private System.Windows.Forms.Label label38;
+        private System.Windows.Forms.ComboBox cbZoomLockLevel;
+        private System.Windows.Forms.Label label44;
+        private System.Windows.Forms.CheckBox cbCrosshairShowOnlyOnSelectedIssues;
+        private System.Windows.Forms.ComboBox cbCrosshairFadeLevel;
+        private System.Windows.Forms.NumericUpDown nmCrosshairLineLength;
+        private System.Windows.Forms.Label label40;
+        private System.Windows.Forms.Label label36;
+        private System.Windows.Forms.Label label41;
+        private System.Windows.Forms.Label label39;
+        private System.Windows.Forms.NumericUpDown nmCrosshairLineMargin;
+        private System.Windows.Forms.CheckBox cbLayerAutoRotateBestView;
+        private System.Windows.Forms.CheckBox cbLayerZoomToFit;
+        private System.Windows.Forms.GroupBox groupBox10;
+        private System.Windows.Forms.Button btnPixelEditorDrainHoleColor;
+        private System.Windows.Forms.Button btnPixelEditorDrainHoleHLColor;
+        private System.Windows.Forms.Label label26;
+        private System.Windows.Forms.Button btnPixelEditorSupportColor;
+        private System.Windows.Forms.Button btnPixelEditorSupportHLColor;
+        private System.Windows.Forms.Label label25;
+        private System.Windows.Forms.Button btnPixelEditorRemovePixelColor;
+        private System.Windows.Forms.Button btnPixelEditorRemovePixelHLColor;
+        private System.Windows.Forms.Label label24;
+        private System.Windows.Forms.Label label23;
+        private System.Windows.Forms.Button btnPixelEditorAddPixelColor;
+        private System.Windows.Forms.Button btnPixelEditorAddPixelHLColor;
     }
 }

--- a/UVtools.GUI/Forms/FrmSettings.cs
+++ b/UVtools.GUI/Forms/FrmSettings.cs
@@ -57,7 +57,8 @@ namespace UVtools.GUI.Forms
                 btnResinTrapColor.BackColor = Settings.Default.ResinTrapColor;
                 btnResinTrapHLColor.BackColor = Settings.Default.ResinTrapHLColor;
                 btnTouchingBoundsColor.BackColor = Settings.Default.TouchingBoundsColor;
-                
+                btnCrosshairColor.BackColor = Settings.Default.CrosshairColor;
+
 
                 btnOutlinePrintVolumeBoundsColor.BackColor = Settings.Default.OutlinePrintVolumeBoundsColor;
                 btnOutlineLayerBoundsColor.BackColor = Settings.Default.OutlineLayerBoundsColor;
@@ -73,7 +74,7 @@ namespace UVtools.GUI.Forms
 
                 cbLayerAutoRotateBestView.Checked = Settings.Default.LayerAutoRotateBestView;
                 cbLayerZoomToFit.Checked = Settings.Default.LayerZoomToFit;
-                cbZoomToFitPrintVolumeBounds.Checked = Settings.Default.ZoomToFitPrintVolumeBounds;
+                cbZoomToFit.SelectedIndex = Settings.Default.ZoomToFitPrintVolumeBounds == true ? 0 : 1;
                 cbZoomIssues.Checked = Settings.Default.ZoomIssues;
                 cbZoomLockLevel.SelectedIndex = Settings.Default.ZoomLockLevel;
                 cbZoomIssuesAuto.Checked = Settings.Default.ZoomIssuesAuto;
@@ -143,6 +144,7 @@ namespace UVtools.GUI.Forms
                 ReferenceEquals(sender, btnResinTrapColor) ||
                 ReferenceEquals(sender, btnResinTrapHLColor) ||
                 ReferenceEquals(sender, btnTouchingBoundsColor) ||
+                ReferenceEquals(sender, btnCrosshairColor) ||
                 ReferenceEquals(sender, btnOutlinePrintVolumeBoundsColor) ||
                 ReferenceEquals(sender, btnOutlineLayerBoundsColor) ||
                 ReferenceEquals(sender, btnOutlineHollowAreasColor) ||
@@ -237,6 +239,7 @@ namespace UVtools.GUI.Forms
                 Settings.Default.ResinTrapColor = btnResinTrapColor.BackColor;
                 Settings.Default.ResinTrapHLColor = btnResinTrapHLColor.BackColor;
                 Settings.Default.TouchingBoundsColor = btnTouchingBoundsColor.BackColor;
+                Settings.Default.CrosshairColor = btnCrosshairColor.BackColor;
 
                 Settings.Default.OutlinePrintVolumeBoundsColor = btnOutlinePrintVolumeBoundsColor.BackColor;
                 Settings.Default.OutlineLayerBoundsColor = btnOutlineLayerBoundsColor.BackColor;
@@ -252,7 +255,7 @@ namespace UVtools.GUI.Forms
 
                 Settings.Default.LayerAutoRotateBestView = cbLayerAutoRotateBestView.Checked;
                 Settings.Default.LayerZoomToFit = cbLayerZoomToFit.Checked;
-                Settings.Default.ZoomToFitPrintVolumeBounds = cbZoomToFitPrintVolumeBounds.Checked;
+                Settings.Default.ZoomToFitPrintVolumeBounds = cbZoomToFit.SelectedIndex == 0 ? true : false;
                 Settings.Default.ZoomIssues = cbZoomIssues.Checked;
                 Settings.Default.ZoomLockLevel = (byte)cbZoomLockLevel.SelectedIndex;
                 Settings.Default.ZoomIssuesAuto = cbZoomIssuesAuto.Checked;

--- a/UVtools.GUI/Forms/FrmSettings.resx
+++ b/UVtools.GUI/Forms/FrmSettings.resx
@@ -125,8 +125,14 @@
   </metadata>
   <data name="cbIslandAllowDiagonalBonds.ToolTip" xml:space="preserve">
     <value> If true, all 8 neighbors of a pixel (including diagonals) will be considered when finding individual components on the layer.
-If false only 4 neighbors (right, left, above, below) will be considered. (Slower but more islands)</value>
+If false only 4 neighbors (right, left, above, below) will be considered. (Slower but more islands detected)</value>
   </data>
+  <data name="nmLayerRepairDefaultOpeningIterations.ToolTip" xml:space="preserve">
+    <value>Default number of noise removal iterations the repair algorithm will apply to remove noise and fine details from the layer.  This setting has the potential to introduce new islands.  Set to 0 to disable.</value>
+  </data>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>47</value>
+  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>

--- a/UVtools.GUI/FrmMain.Designer.cs
+++ b/UVtools.GUI/FrmMain.Designer.cs
@@ -850,7 +850,7 @@ namespace UVtools.GUI
             this.btnLayerImageLayerOutlinePrintVolumeBounds.CheckOnClick = true;
             this.btnLayerImageLayerOutlinePrintVolumeBounds.Name = "btnLayerImageLayerOutlinePrintVolumeBounds";
             this.btnLayerImageLayerOutlinePrintVolumeBounds.Size = new System.Drawing.Size(185, 22);
-            this.btnLayerImageLayerOutlinePrintVolumeBounds.Text = "Print Volume Bounds";
+            this.btnLayerImageLayerOutlinePrintVolumeBounds.Text = "Print Volume Boundary";
             this.btnLayerImageLayerOutlinePrintVolumeBounds.Click += new System.EventHandler(this.EventClick);
             // 
             // btnLayerImageLayerOutlineLayerBounds
@@ -858,7 +858,7 @@ namespace UVtools.GUI
             this.btnLayerImageLayerOutlineLayerBounds.CheckOnClick = true;
             this.btnLayerImageLayerOutlineLayerBounds.Name = "btnLayerImageLayerOutlineLayerBounds";
             this.btnLayerImageLayerOutlineLayerBounds.Size = new System.Drawing.Size(185, 22);
-            this.btnLayerImageLayerOutlineLayerBounds.Text = "Layer Bounds";
+            this.btnLayerImageLayerOutlineLayerBounds.Text = "Layer Boundary";
             this.btnLayerImageLayerOutlineLayerBounds.Click += new System.EventHandler(this.EventClick);
             // 
             // btnLayerImageLayerOutlineHollowAreas

--- a/UVtools.GUI/FrmMain.cs
+++ b/UVtools.GUI/FrmMain.cs
@@ -2496,7 +2496,7 @@ namespace UVtools.GUI
             // This prevents the crosshair lines from disappearing due to being too thin to
             // render at very low zoom factors.
             var lineThickness = (pbLayer.Zoom > 100) ? 1 : (pbLayer.Zoom < 50) ? 3 : 2;
-            var color = new MCvScalar(Settings.Default.CrossharirColor.B, Settings.Default.CrossharirColor.G, Settings.Default.CrossharirColor.R);
+            var color = new MCvScalar(Settings.Default.CrosshairColor.B, Settings.Default.CrosshairColor.G, Settings.Default.CrosshairColor.R);
 
 
             // LEFT

--- a/UVtools.GUI/Properties/Settings.Designer.cs
+++ b/UVtools.GUI/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace UVtools.GUI.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.6.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.7.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -830,12 +830,12 @@ namespace UVtools.GUI.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("Red")]
-        public global::System.Drawing.Color CrossharirColor {
+        public global::System.Drawing.Color CrosshairColor {
             get {
-                return ((global::System.Drawing.Color)(this["CrossharirColor"]));
+                return ((global::System.Drawing.Color)(this["CrosshairColor"]));
             }
             set {
-                this["CrossharirColor"] = value;
+                this["CrosshairColor"] = value;
             }
         }
         

--- a/UVtools.GUI/Properties/Settings.settings
+++ b/UVtools.GUI/Properties/Settings.settings
@@ -203,7 +203,7 @@
     <Setting Name="CrosshairLineMargin" Type="System.Byte" Scope="User">
       <Value Profile="(Default)">5</Value>
     </Setting>
-    <Setting Name="CrossharirColor" Type="System.Drawing.Color" Scope="User">
+    <Setting Name="CrosshairColor" Type="System.Drawing.Color" Scope="User">
       <Value Profile="(Default)">Red</Value>
     </Setting>
     <Setting Name="ZoomIssuesAuto" Type="System.Boolean" Scope="User">


### PR DESCRIPTION
-Adjusted wording for clarity across all tabs
-Adjusted capitilzation for consistency
-Color buttons are now 24x24 instead of 32x32.
-Misc adjustments to spacing and layouts.
-Replaced ZoomToFitiPringBounds checkbox with Combobox and mapped index to existing
config item.
-Added color selection for crosshair.