### PR TITLE
Streamline Layer Repair Dialog

### DIFF
--- a/UVtools.GUI/Forms/FrmToolRepairLayers.Designer.cs
+++ b/UVtools.GUI/Forms/FrmToolRepairLayers.Designer.cs
@@ -32,13 +32,6 @@ namespace UVtools.GUI.Forms
         {
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FrmToolRepairLayers));
-            this.lbDescription = new System.Windows.Forms.Label();
-            this.lbIterationsStart = new System.Windows.Forms.Label();
-            this.numClosingIterations = new System.Windows.Forms.NumericUpDown();
-            this.lbLayerRange = new System.Windows.Forms.Label();
-            this.nmLayerRangeStart = new System.Windows.Forms.NumericUpDown();
-            this.nmLayerRangeEnd = new System.Windows.Forms.NumericUpDown();
-            this.lbLayerRangeTo = new System.Windows.Forms.Label();
             this.cmLayerRange = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.btnLayerRangeAllLayers = new System.Windows.Forms.ToolStripMenuItem();
             this.btnLayerRangeCurrentLayer = new System.Windows.Forms.ToolStripMenuItem();
@@ -48,102 +41,30 @@ namespace UVtools.GUI.Forms
             this.btnRepair = new System.Windows.Forms.Button();
             this.toolTip = new System.Windows.Forms.ToolTip(this.components);
             this.label1 = new System.Windows.Forms.Label();
+            this.lbLayerRange = new System.Windows.Forms.Label();
+            this.lbIterationsStart = new System.Windows.Forms.Label();
             this.cbRepairIslands = new System.Windows.Forms.CheckBox();
-            this.numOpeningIterations = new System.Windows.Forms.NumericUpDown();
             this.cbRepairResinTraps = new System.Windows.Forms.CheckBox();
-            this.btnLayerRangeSelect = new UVtools.GUI.Controls.SplitButton();
             this.cbRemoveEmptyLayers = new System.Windows.Forms.CheckBox();
             this.nmRemoveIslandsBelowEqualPixels = new System.Windows.Forms.NumericUpDown();
             this.label2 = new System.Windows.Forms.Label();
             this.label3 = new System.Windows.Forms.Label();
-            ((System.ComponentModel.ISupportInitialize)(this.numClosingIterations)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nmLayerRangeStart)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nmLayerRangeEnd)).BeginInit();
+            this.groupAdvancedSettings = new System.Windows.Forms.GroupBox();
+            this.numOpeningIterations = new System.Windows.Forms.NumericUpDown();
+            this.lbLayerRangeTo = new System.Windows.Forms.Label();
+            this.nmLayerRangeEnd = new System.Windows.Forms.NumericUpDown();
+            this.nmLayerRangeStart = new System.Windows.Forms.NumericUpDown();
+            this.numClosingIterations = new System.Windows.Forms.NumericUpDown();
+            this.cbAdvancedOptions = new System.Windows.Forms.CheckBox();
+            this.btnLayerRangeSelect = new UVtools.GUI.Controls.SplitButton();
             this.cmLayerRange.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.numOpeningIterations)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nmRemoveIslandsBelowEqualPixels)).BeginInit();
+            this.groupAdvancedSettings.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.numOpeningIterations)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nmLayerRangeEnd)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nmLayerRangeStart)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numClosingIterations)).BeginInit();
             this.SuspendLayout();
-            // 
-            // lbDescription
-            // 
-            this.lbDescription.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lbDescription.Location = new System.Drawing.Point(13, 14);
-            this.lbDescription.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.lbDescription.Name = "lbDescription";
-            this.lbDescription.Size = new System.Drawing.Size(584, 149);
-            this.lbDescription.TabIndex = 0;
-            this.lbDescription.Text = resources.GetString("lbDescription.Text");
-            // 
-            // lbIterationsStart
-            // 
-            this.lbIterationsStart.AutoSize = true;
-            this.lbIterationsStart.Location = new System.Drawing.Point(13, 211);
-            this.lbIterationsStart.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.lbIterationsStart.Name = "lbIterationsStart";
-            this.lbIterationsStart.Size = new System.Drawing.Size(171, 20);
-            this.lbIterationsStart.TabIndex = 3;
-            this.lbIterationsStart.Text = "Gap Closing Iterations:";
-            this.toolTip.SetToolTip(this.lbIterationsStart, resources.GetString("lbIterationsStart.ToolTip"));
-            // 
-            // numClosingIterations
-            // 
-            this.numClosingIterations.Location = new System.Drawing.Point(192, 208);
-            this.numClosingIterations.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.numClosingIterations.Name = "numClosingIterations";
-            this.numClosingIterations.Size = new System.Drawing.Size(89, 26);
-            this.numClosingIterations.TabIndex = 3;
-            this.numClosingIterations.Value = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-            // 
-            // lbLayerRange
-            // 
-            this.lbLayerRange.AutoSize = true;
-            this.lbLayerRange.Location = new System.Drawing.Point(13, 171);
-            this.lbLayerRange.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.lbLayerRange.Name = "lbLayerRange";
-            this.lbLayerRange.Size = new System.Drawing.Size(97, 20);
-            this.lbLayerRange.TabIndex = 9;
-            this.lbLayerRange.Text = "Layer range:";
-            this.toolTip.SetToolTip(this.lbLayerRange, resources.GetString("lbLayerRange.ToolTip"));
-            // 
-            // nmLayerRangeStart
-            // 
-            this.nmLayerRangeStart.Location = new System.Drawing.Point(157, 168);
-            this.nmLayerRangeStart.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.nmLayerRangeStart.Maximum = new decimal(new int[] {
-            100000,
-            0,
-            0,
-            0});
-            this.nmLayerRangeStart.Name = "nmLayerRangeStart";
-            this.nmLayerRangeStart.Size = new System.Drawing.Size(124, 26);
-            this.nmLayerRangeStart.TabIndex = 0;
-            // 
-            // nmLayerRangeEnd
-            // 
-            this.nmLayerRangeEnd.Location = new System.Drawing.Point(328, 168);
-            this.nmLayerRangeEnd.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.nmLayerRangeEnd.Maximum = new decimal(new int[] {
-            100000,
-            0,
-            0,
-            0});
-            this.nmLayerRangeEnd.Name = "nmLayerRangeEnd";
-            this.nmLayerRangeEnd.Size = new System.Drawing.Size(124, 26);
-            this.nmLayerRangeEnd.TabIndex = 1;
-            // 
-            // lbLayerRangeTo
-            // 
-            this.lbLayerRangeTo.AutoSize = true;
-            this.lbLayerRangeTo.Location = new System.Drawing.Point(289, 171);
-            this.lbLayerRangeTo.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.lbLayerRangeTo.Name = "lbLayerRangeTo";
-            this.lbLayerRangeTo.Size = new System.Drawing.Size(31, 20);
-            this.lbLayerRangeTo.TabIndex = 12;
-            this.lbLayerRangeTo.Text = "To:";
             // 
             // cmLayerRange
             // 
@@ -197,7 +118,7 @@ namespace UVtools.GUI.Forms
             this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
             this.btnCancel.Image = global::UVtools.GUI.Properties.Resources.Cancel_24x24;
             this.btnCancel.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.btnCancel.Location = new System.Drawing.Point(447, 286);
+            this.btnCancel.Location = new System.Drawing.Point(434, 285);
             this.btnCancel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(150, 48);
@@ -212,7 +133,7 @@ namespace UVtools.GUI.Forms
             this.btnRepair.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.btnRepair.Image = global::UVtools.GUI.Properties.Resources.Ok_24x24;
             this.btnRepair.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.btnRepair.Location = new System.Drawing.Point(289, 286);
+            this.btnRepair.Location = new System.Drawing.Point(276, 285);
             this.btnRepair.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.btnRepair.Name = "btnRepair";
             this.btnRepair.Size = new System.Drawing.Size(150, 48);
@@ -234,76 +155,79 @@ namespace UVtools.GUI.Forms
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(307, 210);
+            this.label1.Location = new System.Drawing.Point(12, 109);
             this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(190, 20);
-            this.label1.TabIndex = 17;
+            this.label1.TabIndex = 26;
             this.label1.Text = "Noise Removal Iterations:";
             this.toolTip.SetToolTip(this.label1, resources.GetString("label1.ToolTip"));
+            // 
+            // lbLayerRange
+            // 
+            this.lbLayerRange.AutoSize = true;
+            this.lbLayerRange.Location = new System.Drawing.Point(12, 35);
+            this.lbLayerRange.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lbLayerRange.Name = "lbLayerRange";
+            this.lbLayerRange.Size = new System.Drawing.Size(115, 20);
+            this.lbLayerRange.TabIndex = 24;
+            this.lbLayerRange.Text = "Process layers:";
+            this.toolTip.SetToolTip(this.lbLayerRange, "Selects the layer range on which the repair operation will be performed.   Start " +
+        "layer must be lower than end layer.");
+            // 
+            // lbIterationsStart
+            // 
+            this.lbIterationsStart.AutoSize = true;
+            this.lbIterationsStart.Location = new System.Drawing.Point(12, 71);
+            this.lbIterationsStart.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lbIterationsStart.Name = "lbIterationsStart";
+            this.lbIterationsStart.Size = new System.Drawing.Size(171, 20);
+            this.lbIterationsStart.TabIndex = 23;
+            this.lbIterationsStart.Text = "Gap Closing Iterations:";
+            this.toolTip.SetToolTip(this.lbIterationsStart, resources.GetString("lbIterationsStart.ToolTip"));
             // 
             // cbRepairIslands
             // 
             this.cbRepairIslands.AutoSize = true;
             this.cbRepairIslands.Checked = true;
             this.cbRepairIslands.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cbRepairIslands.Location = new System.Drawing.Point(17, 246);
+            this.cbRepairIslands.Location = new System.Drawing.Point(16, 25);
             this.cbRepairIslands.Name = "cbRepairIslands";
-            this.cbRepairIslands.Size = new System.Drawing.Size(204, 24);
+            this.cbRepairIslands.Size = new System.Drawing.Size(128, 24);
             this.cbRepairIslands.TabIndex = 16;
-            this.cbRepairIslands.Text = "Repair layers and islands";
+            this.cbRepairIslands.Text = "Repair islands";
+            this.toolTip.SetToolTip(this.cbRepairIslands, "If enabled, repair will first attempt to elimnate islands using the gap closure t" +
+        "echnique, and then remove any remaining islands smaller than the pixel area remo" +
+        "val threshold.");
             this.cbRepairIslands.UseVisualStyleBackColor = true;
-            // 
-            // numOpeningIterations
-            // 
-            this.numOpeningIterations.Location = new System.Drawing.Point(505, 208);
-            this.numOpeningIterations.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.numOpeningIterations.Name = "numOpeningIterations";
-            this.numOpeningIterations.Size = new System.Drawing.Size(92, 26);
-            this.numOpeningIterations.TabIndex = 18;
-            this.numOpeningIterations.Value = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
             // 
             // cbRepairResinTraps
             // 
             this.cbRepairResinTraps.AutoSize = true;
             this.cbRepairResinTraps.Checked = true;
             this.cbRepairResinTraps.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cbRepairResinTraps.Location = new System.Drawing.Point(17, 305);
+            this.cbRepairResinTraps.Location = new System.Drawing.Point(206, 25);
             this.cbRepairResinTraps.Name = "cbRepairResinTraps";
-            this.cbRepairResinTraps.Size = new System.Drawing.Size(164, 24);
+            this.cbRepairResinTraps.Size = new System.Drawing.Size(153, 24);
             this.cbRepairResinTraps.TabIndex = 19;
-            this.cbRepairResinTraps.Text = "Repair Resin Traps";
+            this.cbRepairResinTraps.Text = "Repair resin traps";
             this.cbRepairResinTraps.UseVisualStyleBackColor = true;
-            // 
-            // btnLayerRangeSelect
-            // 
-            this.btnLayerRangeSelect.Location = new System.Drawing.Point(459, 168);
-            this.btnLayerRangeSelect.Menu = this.cmLayerRange;
-            this.btnLayerRangeSelect.Name = "btnLayerRangeSelect";
-            this.btnLayerRangeSelect.Size = new System.Drawing.Size(138, 26);
-            this.btnLayerRangeSelect.TabIndex = 2;
-            this.btnLayerRangeSelect.Text = "Select";
-            this.btnLayerRangeSelect.UseVisualStyleBackColor = true;
             // 
             // cbRemoveEmptyLayers
             // 
             this.cbRemoveEmptyLayers.AutoSize = true;
             this.cbRemoveEmptyLayers.Checked = true;
             this.cbRemoveEmptyLayers.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cbRemoveEmptyLayers.Location = new System.Drawing.Point(17, 276);
+            this.cbRemoveEmptyLayers.Location = new System.Drawing.Point(408, 25);
             this.cbRemoveEmptyLayers.Name = "cbRemoveEmptyLayers";
             this.cbRemoveEmptyLayers.Size = new System.Drawing.Size(179, 24);
             this.cbRemoveEmptyLayers.TabIndex = 20;
             this.cbRemoveEmptyLayers.Text = "Remove empty layers";
             this.cbRemoveEmptyLayers.UseVisualStyleBackColor = true;
             // 
-            // nmRemoveIslandsBelowEqual
+            // nmRemoveIslandsBelowEqualPixels
             // 
-            this.nmRemoveIslandsBelowEqualPixels.Location = new System.Drawing.Point(505, 245);
+            this.nmRemoveIslandsBelowEqualPixels.Location = new System.Drawing.Point(263, 66);
             this.nmRemoveIslandsBelowEqualPixels.Maximum = new decimal(new int[] {
             255,
             0,
@@ -312,49 +236,153 @@ namespace UVtools.GUI.Forms
             this.nmRemoveIslandsBelowEqualPixels.Name = "nmRemoveIslandsBelowEqualPixels";
             this.nmRemoveIslandsBelowEqualPixels.Size = new System.Drawing.Size(58, 26);
             this.nmRemoveIslandsBelowEqualPixels.TabIndex = 21;
+            this.toolTip.SetToolTip(this.nmRemoveIslandsBelowEqualPixels, "The pixel area theshold above which islands will not be removed by this repair.  " +
+        " Islands remaining after repair will require supports to be added manually.");
             // 
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(248, 248);
+            this.label2.Location = new System.Drawing.Point(12, 69);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(249, 20);
+            this.label2.Size = new System.Drawing.Size(250, 20);
             this.label2.TabIndex = 22;
-            this.label2.Text = "Remove islands below or equal to:";
+            this.label2.Text = "Do not remove islands larger than:";
+            this.toolTip.SetToolTip(this.label2, "The pixel area theshold above which islands will not be removed by this repair.  " +
+        " Islands remaining after repair will require supports to be added manually.");
             // 
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(569, 248);
+            this.label3.Location = new System.Drawing.Point(323, 67);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(25, 20);
             this.label3.TabIndex = 23;
             this.label3.Text = "px";
             // 
-            // FrmRepairLayers
+            // groupAdvancedSettings
+            // 
+            this.groupAdvancedSettings.Controls.Add(this.numOpeningIterations);
+            this.groupAdvancedSettings.Controls.Add(this.label1);
+            this.groupAdvancedSettings.Controls.Add(this.btnLayerRangeSelect);
+            this.groupAdvancedSettings.Controls.Add(this.lbLayerRangeTo);
+            this.groupAdvancedSettings.Controls.Add(this.nmLayerRangeEnd);
+            this.groupAdvancedSettings.Controls.Add(this.nmLayerRangeStart);
+            this.groupAdvancedSettings.Controls.Add(this.lbLayerRange);
+            this.groupAdvancedSettings.Controls.Add(this.numClosingIterations);
+            this.groupAdvancedSettings.Controls.Add(this.lbIterationsStart);
+            this.groupAdvancedSettings.Location = new System.Drawing.Point(4, 109);
+            this.groupAdvancedSettings.Name = "groupAdvancedSettings";
+            this.groupAdvancedSettings.Size = new System.Drawing.Size(590, 146);
+            this.groupAdvancedSettings.TabIndex = 24;
+            this.groupAdvancedSettings.TabStop = false;
+            this.groupAdvancedSettings.Text = "Advanced Settings";
+            this.groupAdvancedSettings.Visible = false;
+            // 
+            // numOpeningIterations
+            // 
+            this.numOpeningIterations.Location = new System.Drawing.Point(202, 107);
+            this.numOpeningIterations.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.numOpeningIterations.Name = "numOpeningIterations";
+            this.numOpeningIterations.Size = new System.Drawing.Size(92, 26);
+            this.numOpeningIterations.TabIndex = 27;
+            this.toolTip.SetToolTip(this.numOpeningIterations, resources.GetString("numOpeningIterations.ToolTip"));
+            this.numOpeningIterations.Value = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            // 
+            // lbLayerRangeTo
+            // 
+            this.lbLayerRangeTo.AutoSize = true;
+            this.lbLayerRangeTo.Location = new System.Drawing.Point(243, 35);
+            this.lbLayerRangeTo.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lbLayerRangeTo.Name = "lbLayerRangeTo";
+            this.lbLayerRangeTo.Size = new System.Drawing.Size(31, 20);
+            this.lbLayerRangeTo.TabIndex = 25;
+            this.lbLayerRangeTo.Text = "To:";
+            // 
+            // nmLayerRangeEnd
+            // 
+            this.nmLayerRangeEnd.Location = new System.Drawing.Point(282, 32);
+            this.nmLayerRangeEnd.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.nmLayerRangeEnd.Maximum = new decimal(new int[] {
+            100000,
+            0,
+            0,
+            0});
+            this.nmLayerRangeEnd.Name = "nmLayerRangeEnd";
+            this.nmLayerRangeEnd.Size = new System.Drawing.Size(102, 26);
+            this.nmLayerRangeEnd.TabIndex = 20;
+            this.toolTip.SetToolTip(this.nmLayerRangeEnd, "End Layer");
+            // 
+            // nmLayerRangeStart
+            // 
+            this.nmLayerRangeStart.Location = new System.Drawing.Point(133, 32);
+            this.nmLayerRangeStart.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.nmLayerRangeStart.Maximum = new decimal(new int[] {
+            100000,
+            0,
+            0,
+            0});
+            this.nmLayerRangeStart.Name = "nmLayerRangeStart";
+            this.nmLayerRangeStart.Size = new System.Drawing.Size(102, 26);
+            this.nmLayerRangeStart.TabIndex = 19;
+            this.toolTip.SetToolTip(this.nmLayerRangeStart, "Start Layer");
+            // 
+            // numClosingIterations
+            // 
+            this.numClosingIterations.Location = new System.Drawing.Point(184, 69);
+            this.numClosingIterations.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.numClosingIterations.Name = "numClosingIterations";
+            this.numClosingIterations.Size = new System.Drawing.Size(89, 26);
+            this.numClosingIterations.TabIndex = 22;
+            this.toolTip.SetToolTip(this.numClosingIterations, resources.GetString("numClosingIterations.ToolTip"));
+            this.numClosingIterations.Value = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            // 
+            // cbAdvancedOptions
+            // 
+            this.cbAdvancedOptions.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.cbAdvancedOptions.AutoSize = true;
+            this.cbAdvancedOptions.Location = new System.Drawing.Point(16, 298);
+            this.cbAdvancedOptions.Name = "cbAdvancedOptions";
+            this.cbAdvancedOptions.Size = new System.Drawing.Size(202, 24);
+            this.cbAdvancedOptions.TabIndex = 25;
+            this.cbAdvancedOptions.Text = "Show Advanced Options";
+            this.cbAdvancedOptions.UseVisualStyleBackColor = true;
+            this.cbAdvancedOptions.CheckedChanged += new System.EventHandler(this.cbAdvancedOptions_CheckedChanged);
+            // 
+            // btnLayerRangeSelect
+            // 
+            this.btnLayerRangeSelect.Location = new System.Drawing.Point(399, 32);
+            this.btnLayerRangeSelect.Menu = this.cmLayerRange;
+            this.btnLayerRangeSelect.Name = "btnLayerRangeSelect";
+            this.btnLayerRangeSelect.Size = new System.Drawing.Size(102, 26);
+            this.btnLayerRangeSelect.TabIndex = 21;
+            this.btnLayerRangeSelect.Text = "Select";
+            this.toolTip.SetToolTip(this.btnLayerRangeSelect, "Select specific subsets of layers");
+            this.btnLayerRangeSelect.UseVisualStyleBackColor = true;
+            // 
+            // FrmToolRepairLayers
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.btnCancel;
-            this.ClientSize = new System.Drawing.Size(606, 348);
+            this.ClientSize = new System.Drawing.Size(599, 347);
+            this.Controls.Add(this.cbAdvancedOptions);
+            this.Controls.Add(this.groupAdvancedSettings);
             this.Controls.Add(this.label3);
             this.Controls.Add(this.label2);
             this.Controls.Add(this.nmRemoveIslandsBelowEqualPixels);
             this.Controls.Add(this.cbRemoveEmptyLayers);
             this.Controls.Add(this.cbRepairResinTraps);
-            this.Controls.Add(this.numOpeningIterations);
-            this.Controls.Add(this.label1);
             this.Controls.Add(this.cbRepairIslands);
-            this.Controls.Add(this.btnLayerRangeSelect);
-            this.Controls.Add(this.lbLayerRangeTo);
-            this.Controls.Add(this.nmLayerRangeEnd);
-            this.Controls.Add(this.nmLayerRangeStart);
-            this.Controls.Add(this.lbLayerRange);
             this.Controls.Add(this.btnRepair);
             this.Controls.Add(this.btnCancel);
-            this.Controls.Add(this.numClosingIterations);
-            this.Controls.Add(this.lbIterationsStart);
-            this.Controls.Add(this.lbDescription);
             this.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
@@ -362,34 +390,28 @@ namespace UVtools.GUI.Forms
             this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
-            this.Name = "FrmRepairLayers";
+            this.Name = "FrmToolRepairLayers";
             this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Repair Layers";
             this.TopMost = true;
-            ((System.ComponentModel.ISupportInitialize)(this.numClosingIterations)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nmLayerRangeStart)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nmLayerRangeEnd)).EndInit();
+            this.Load += new System.EventHandler(this.FrmToolRepairLayers_Load);
             this.cmLayerRange.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.numOpeningIterations)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nmRemoveIslandsBelowEqualPixels)).EndInit();
+            this.groupAdvancedSettings.ResumeLayout(false);
+            this.groupAdvancedSettings.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.numOpeningIterations)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nmLayerRangeEnd)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nmLayerRangeStart)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numClosingIterations)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
         }
 
         #endregion
-
-        private System.Windows.Forms.Label lbDescription;
-        private System.Windows.Forms.Label lbIterationsStart;
-        private System.Windows.Forms.NumericUpDown numClosingIterations;
         private System.Windows.Forms.Button btnCancel;
         private System.Windows.Forms.Button btnRepair;
-        private System.Windows.Forms.Label lbLayerRange;
-        private System.Windows.Forms.NumericUpDown nmLayerRangeStart;
-        private System.Windows.Forms.NumericUpDown nmLayerRangeEnd;
-        private System.Windows.Forms.Label lbLayerRangeTo;
-        private Controls.SplitButton btnLayerRangeSelect;
         private System.Windows.Forms.ContextMenuStrip cmLayerRange;
         private System.Windows.Forms.ToolStripMenuItem btnLayerRangeAllLayers;
         private System.Windows.Forms.ToolStripMenuItem btnLayerRangeCurrentLayer;
@@ -397,12 +419,21 @@ namespace UVtools.GUI.Forms
         private System.Windows.Forms.ToolStripMenuItem btnLayerRangeNormalLayers;
         private System.Windows.Forms.ToolTip toolTip;
         private System.Windows.Forms.CheckBox cbRepairIslands;
-        private System.Windows.Forms.Label label1;
-        private System.Windows.Forms.NumericUpDown numOpeningIterations;
         private System.Windows.Forms.CheckBox cbRepairResinTraps;
         private System.Windows.Forms.CheckBox cbRemoveEmptyLayers;
         private System.Windows.Forms.NumericUpDown nmRemoveIslandsBelowEqualPixels;
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.GroupBox groupAdvancedSettings;
+        private System.Windows.Forms.NumericUpDown numOpeningIterations;
+        private System.Windows.Forms.Label label1;
+        private SplitButton btnLayerRangeSelect;
+        private System.Windows.Forms.Label lbLayerRangeTo;
+        private System.Windows.Forms.NumericUpDown nmLayerRangeEnd;
+        private System.Windows.Forms.NumericUpDown nmLayerRangeStart;
+        private System.Windows.Forms.Label lbLayerRange;
+        private System.Windows.Forms.NumericUpDown numClosingIterations;
+        private System.Windows.Forms.Label lbIterationsStart;
+        private System.Windows.Forms.CheckBox cbAdvancedOptions;
     }
 }

--- a/UVtools.GUI/Forms/FrmToolRepairLayers.cs
+++ b/UVtools.GUI/Forms/FrmToolRepairLayers.cs
@@ -204,9 +204,38 @@ namespace UVtools.GUI.Forms
             }
         }
 
-        
+
+
         #endregion
 
+        private void cbAdvancedOptions_CheckedChanged(object sender, EventArgs e)
+        {
+            if (cbAdvancedOptions.Checked)
+            {
+                if (groupAdvancedSettings.Visible == false)
+                {
+                    groupAdvancedSettings.Visible = true;
+                    FrmToolRepairLayers.ActiveForm.Height += groupAdvancedSettings.Height;
+                }
+            }
+            else
+            {
+                if (groupAdvancedSettings.Visible == true)
+                {
+                    groupAdvancedSettings.Visible = false;
+                    FrmToolRepairLayers.ActiveForm.Height -= groupAdvancedSettings.Height;
+                }
+            }
+        }
 
+        private void FrmToolRepairLayers_Load(object sender, EventArgs e)
+        {
+            cbAdvancedOptions.Checked = false;
+            groupAdvancedSettings.Visible = false;
+
+
+
+            FrmToolRepairLayers.ActiveForm.Height -= groupAdvancedSettings.Height;
+        }
     }
 }

--- a/UVtools.GUI/Forms/FrmToolRepairLayers.resx
+++ b/UVtools.GUI/Forms/FrmToolRepairLayers.resx
@@ -117,24 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="lbDescription.Text" xml:space="preserve">
-    <value>Try to repair layers by removing noise/isolated pixels and fill lost pixels.
-Island repair are done by tring attach the island to another nearby island(s) in safe increments, if fails, next try to remove the island if it size is smaller than a threshold.
-In the end if island remains is not safe to perform any automatic operation and there before you must take care of if manually, in this case islands are too far from land and in many cases it will require a support to proper fix.</value>
-  </data>
-  <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>148, 17</value>
-  </metadata>
-  <data name="lbIterationsStart.ToolTip" xml:space="preserve">
-    <value>Selects the number of iterations/passes to perform on each layer.
-Choose 0 to disable this step.
-WARNING: Using high iteration values can destroy your model depending on the mutator being used, please use low values or with caution!</value>
-  </data>
-  <data name="lbLayerRange.ToolTip" xml:space="preserve">
-    <value>Selects the layers range within start layer and end layer where mutator will operate.
-Select same layer start as end to operate only within that layer.
-Note: "Layer Start" start can't be higher than "Layer End".</value>
-  </data>
   <metadata name="cmLayerRange.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
@@ -142,9 +124,25 @@ Note: "Layer Start" start can't be higher than "Layer End".</value>
     <value>148, 17</value>
   </metadata>
   <data name="label1.ToolTip" xml:space="preserve">
-    <value>Selects the number of iterations/passes to perform on each layer.
-Choose 0 to disable this step.
-WARNING: Using high iteration values can destroy your model depending on the mutator being used, please use low values or with caution!</value>
+    <value>Remove individual or small clusters of pixels in iterations.  This settings can remove noise from a layer, but will also remove fine details.
+Set iterations to 0 to diasble.
+WARNING: Even at low settings this operation has the potential to introduce new islands, as it may remove supporting material from previous layers.
+</value>
+  </data>
+  <data name="lbIterationsStart.ToolTip" xml:space="preserve">
+    <value>Attempt to repair islands by attaching them to other nearby islands in safe increments.  If enabled, gap closing is attempted before island removal is attempted.
+Set iterations to 0 to disable.
+WARNING: Using high iteration values can destroy your model.  Low values recomended.</value>
+  </data>
+  <data name="numOpeningIterations.ToolTip" xml:space="preserve">
+    <value>Remove individual or small clusters of pixels in iterations.  This settings can remove noise from a layer, but will also remove fine details.
+Set iterations to 0 to diasble.
+WARNING: Even at low settings this operation has the potential to introduce new islands, as it may remove supporting material from previous layers.</value>
+  </data>
+  <data name="numClosingIterations.ToolTip" xml:space="preserve">
+    <value>Attempt to repair islands by attaching them to other nearby islands in safe increments.  If enabled, gap closing is attempted before island removal is attempted.
+Set iterations to 0 to disable.
+WARNING: Using high iteration values can destroy your model.  Low values recomended.</value>
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">


### PR DESCRIPTION
Detailed description and warning text in this dialog has been moved from main form into tooltips.  It's useful information for new users, but not needed to be visible each time repair is run.

Less frequently used settings for gap and noise removal iterations have been moved to an advanced settings group that
is hidden by default, and can be shown if changes in those settings is desired.  For many users, those advanced settings can be left on default and never adjusted.