### PR TITLE
Swap Location of Zoom out to Fit & Autozoom options

### DIFF
--- a/UVtools.GUI/Forms/FrmSettings.Designer.cs
+++ b/UVtools.GUI/Forms/FrmSettings.Designer.cs
@@ -1465,7 +1465,7 @@
             // label43
             // 
             this.label43.AutoSize = true;
-            this.label43.Location = new System.Drawing.Point(8, 61);
+            this.label43.Location = new System.Drawing.Point(8, 27);
             this.label43.Name = "label43";
             this.label43.Size = new System.Drawing.Size(109, 18);
             this.label43.TabIndex = 57;
@@ -1480,7 +1480,7 @@
             this.cbZoomToFit.Items.AddRange(new object[] {
             "Print Volume Boundary",
             "Layer Boundary"});
-            this.cbZoomToFit.Location = new System.Drawing.Point(123, 57);
+            this.cbZoomToFit.Location = new System.Drawing.Point(123, 23);
             this.cbZoomToFit.Name = "cbZoomToFit";
             this.cbZoomToFit.Size = new System.Drawing.Size(188, 26);
             this.cbZoomToFit.TabIndex = 55;
@@ -1490,7 +1490,7 @@
             // cbZoomIssues
             // 
             this.cbZoomIssues.AutoSize = true;
-            this.cbZoomIssues.Location = new System.Drawing.Point(11, 25);
+            this.cbZoomIssues.Location = new System.Drawing.Point(11, 60);
             this.cbZoomIssues.Name = "cbZoomIssues";
             this.cbZoomIssues.Size = new System.Drawing.Size(290, 22);
             this.cbZoomIssues.TabIndex = 52;


### PR DESCRIPTION
After removal of the "Zoom out Large Issues" option in the settings checkbox, I was just glancing at the settings and thought the
Zoom group would look bettter with the dropdowns for Zoom In and Zoom Out at the top, and the checkbox option to enable zoom on single click at the bottom.

This is a very minor adjustment, so take it or leave it, either way is fine.  I went ahead and changed it in my fork just to see how it looked, liked it, so figured I'd submit.

![Settings](https://user-images.githubusercontent.com/7484658/92331499-3b2d1f80-f034-11ea-9bde-afb118297a9a.png)
