### PR TITLE
Fix inconsistencies on pixel edit apply confirm dialog

### DIFF
--- a/UVtools.GUI/App.config
+++ b/UVtools.GUI/App.config
@@ -220,6 +220,9 @@
       <setting name="PartialUpdateIslandsOnEditing" serializeAs="String">
         <value>True</value>
       </setting>
+      <setting name="CloseEditOnApply" serializeAs="String">
+        <value>False</value>
+      </setting>
       <setting name="IslandAllowDiagonalBonds" serializeAs="String">
         <value>False</value>
       </setting>

--- a/UVtools.GUI/Forms/FrmSettings.Designer.cs
+++ b/UVtools.GUI/Forms/FrmSettings.Designer.cs
@@ -173,6 +173,7 @@
             this.cbLayerRepairLayersIslands = new System.Windows.Forms.CheckBox();
             this.panel1 = new System.Windows.Forms.Panel();
             this.toolTip = new System.Windows.Forms.ToolTip(this.components);
+            this.cbCloseEditOnApply = new System.Windows.Forms.CheckBox();
             this.groupBox3.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nmResinTrapBinaryThreshold)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nmResinTrapMaximumPixelBrightnessToDrain)).BeginInit();
@@ -1698,6 +1699,7 @@
             // 
             // tabPage4
             // 
+            this.tabPage4.Controls.Add(this.cbCloseEditOnApply);
             this.tabPage4.Controls.Add(this.groupBox10);
             this.tabPage4.Controls.Add(this.cbPartialUpdateIslandsOnEditing);
             this.tabPage4.Location = new System.Drawing.Point(4, 27);
@@ -2055,6 +2057,17 @@
             this.toolTip.ToolTipIcon = System.Windows.Forms.ToolTipIcon.Info;
             this.toolTip.ToolTipTitle = "Information";
             // 
+            // cbCloseEditOnApply
+            // 
+            this.cbCloseEditOnApply.AutoSize = true;
+            this.cbCloseEditOnApply.Location = new System.Drawing.Point(11, 213);
+            this.cbCloseEditOnApply.Name = "cbCloseEditOnApply";
+            this.cbCloseEditOnApply.Size = new System.Drawing.Size(322, 22);
+            this.cbCloseEditOnApply.TabIndex = 25;
+            this.cbCloseEditOnApply.Text = "Close pixel editor after operations are applied";
+            this.toolTip.SetToolTip(this.cbCloseEditOnApply, "Automatically close pixel editor after applying changes");
+            this.cbCloseEditOnApply.UseVisualStyleBackColor = true;
+            // 
             // FrmSettings
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 18F);
@@ -2266,5 +2279,6 @@
         private System.Windows.Forms.Label label23;
         private System.Windows.Forms.Button btnPixelEditorAddPixelColor;
         private System.Windows.Forms.Button btnPixelEditorAddPixelHLColor;
+        private System.Windows.Forms.CheckBox cbCloseEditOnApply;
     }
 }

--- a/UVtools.GUI/Forms/FrmSettings.cs
+++ b/UVtools.GUI/Forms/FrmSettings.cs
@@ -113,6 +113,7 @@ namespace UVtools.GUI.Forms
                 btnPixelEditorDrainHoleColor.BackColor = Settings.Default.PixelEditorDrainHoleColor;
                 btnPixelEditorDrainHoleHLColor.BackColor = Settings.Default.PixelEditorDrainHoleHLColor;
                 cbPartialUpdateIslandsOnEditing.Checked = Settings.Default.PartialUpdateIslandsOnEditing;
+                cbCloseEditOnApply.Checked = Settings.Default.CloseEditOnApply;
 
                 // Layer Repair
                 nmLayerRepairDefaultClosingIterations.Value = Settings.Default.LayerRepairDefaultClosingIterations;
@@ -293,6 +294,7 @@ namespace UVtools.GUI.Forms
                 Settings.Default.PixelEditorSupportHLColor = btnPixelEditorSupportHLColor.BackColor;
                 Settings.Default.PixelEditorDrainHoleHLColor = btnPixelEditorDrainHoleHLColor.BackColor;
                 Settings.Default.PartialUpdateIslandsOnEditing = cbPartialUpdateIslandsOnEditing.Checked;
+                Settings.Default.CloseEditOnApply = cbCloseEditOnApply.Checked;
 
                 // Layer Repair
                 Settings.Default.LayerRepairDefaultClosingIterations = (byte) nmLayerRepairDefaultClosingIterations.Value;

--- a/UVtools.GUI/FrmMain.cs
+++ b/UVtools.GUI/FrmMain.cs
@@ -4275,10 +4275,27 @@ namespace UVtools.GUI
                 }
                 return;
             }
-            var result = MessageBox.Show(
-                                "There are unsaved changes on image editor, do you want to apply modifications?",
-                                "Unsaved changes on image editor", MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question);
 
+            var result = DialogResult.None;
+
+            if (exitEditor) {
+               result =  MessageBox.Show(
+                   "There are edit operations that have not been applied.  " +
+                   "Would you like to apply all operations before closing the editor?",
+                   "Closing image editor", MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question);
+            }
+            else
+            {
+
+                result = MessageBox.Show(
+                    "Are you sure you want to apply all operations?",
+                    "Apply image editor changes?", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+
+                // For the "apply" case, We aren't exiting the editor, so map "No" to "Cancel" here
+                // in order to prevent pixel history from being cleared.
+                result = result == DialogResult.No ? DialogResult.Cancel : DialogResult.Yes;
+            }
+            
             if (result == DialogResult.Cancel)
             {
                 btnLayerImagePixelEdit.Checked = true;
@@ -4340,8 +4357,9 @@ namespace UVtools.GUI
                 }
             }
 
-            if (exitEditor)
+            if (exitEditor || (Settings.Default.CloseEditOnApply && result == DialogResult.Yes))
             {
+                btnLayerImagePixelEdit.Checked = false;
                 tabControlLeft.SelectedTab = ControlLeftLastTab;
                 tabControlLeft.TabPages.Remove(tabPagePixelEditor);
             }

--- a/UVtools.GUI/Properties/Settings.Designer.cs
+++ b/UVtools.GUI/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace UVtools.GUI.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.6.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.7.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -776,6 +776,18 @@ namespace UVtools.GUI.Properties {
             }
             set {
                 this["PartialUpdateIslandsOnEditing"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool CloseEditOnApply {
+            get {
+                return ((bool)(this["CloseEditOnApply"]));
+            }
+            set {
+                this["CloseEditOnApply"] = value;
             }
         }
         

--- a/UVtools.GUI/Properties/Settings.settings
+++ b/UVtools.GUI/Properties/Settings.settings
@@ -191,6 +191,9 @@
     <Setting Name="PartialUpdateIslandsOnEditing" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="CloseEditOnApply" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
     <Setting Name="IslandAllowDiagonalBonds" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>


### PR DESCRIPTION
The same MessageBox dialog in the pixel edit mode is used for both applying operations, and exiting pixel edit mode.

As a result, the text prompt feels a little out of context for the apply case, and this also results in pixel history getting cleared if you choose "No" on this dialog.  This makes sense if you are exiting pixel edit mode, but not if you just hit apply and changed your mind.

I added a separate dialog for the Apply case that only has the options "Yes/No".  Yes applies the changes, No behaves like Cancel.

Also added a new setting in the settings dialog so that pixel editor can be configured to exit after each apply operation.  I found I was applying operations and then going off and doing other things without realizing I was still in pixel edit mode, so thought this would be a good option to have.