### PR TITLE
Text Refresh for Operation Move and Resize

### DIFF
--- a/UVtools.Core/Operations/OperationFlip.cs
+++ b/UVtools.Core/Operations/OperationFlip.cs
@@ -14,15 +14,19 @@ namespace UVtools.Core.Operations
     {
         public override string Title => "Flip";
         public override string Description =>
-            "Flips layer images vertically and/or horizontally.";
+            "Flip the layers of the model vertically and/or horizontally.";
 
         public override string ConfirmationText =>
-            $"flip {FlipDirection} from layers {LayerIndexStart} to {LayerIndexEnd}";
+            FlipDirection == Enumerations.FlipDirection.Both
+                ? $"flip {(MakeCopy == true? "and blend ":"")}layers {LayerIndexStart} through {LayerIndexEnd} Horizontally and Vertically?"
+                : $"flip {(MakeCopy == true ? "and blend " : "")}layers {LayerIndexStart} through {LayerIndexEnd} {FlipDirection}?";
 
         public override string ProgressTitle =>
-            $"Flipping {FlipDirection} from layers {LayerIndexStart} to {LayerIndexEnd}";
+            FlipDirection == Enumerations.FlipDirection.Both
+                ? $"Flipping {(MakeCopy == true ? "and blending " : "")}layers {LayerIndexStart} through {LayerIndexEnd} Horizontally and Vertically"
+                : $"Flipping {(MakeCopy == true ? "and blending " : "")}layers {LayerIndexStart} through {LayerIndexEnd} {FlipDirection}";
 
-        public override string ProgressAction => "Flipped layers";
+        public override string ProgressAction => "Flipping layers";
         
         public Enumerations.FlipDirection FlipDirection { get; set; }
 

--- a/UVtools.Core/Operations/OperationMorph.cs
+++ b/UVtools.Core/Operations/OperationMorph.cs
@@ -17,15 +17,15 @@ namespace UVtools.Core.Operations
 
         public override string Title => "Morph";
         public override string Description =>
-            $"Morph Model\n" +
-            $"Various operations that can be used to change the physical structure of the model or individual layers in various ways.";
+            $"Morph Model - " +
+            $"Various operations that can be used to change the physical structure of the model or individual layers.";
         public override string ConfirmationText =>
-            $"morph model from layers {LayerIndexStart} to {LayerIndexEnd}?";
+            $"morph model layers {LayerIndexStart} through {LayerIndexEnd}?";
 
         public override string ProgressTitle =>
-            $"Morphing layers from {LayerIndexStart} to {LayerIndexEnd}";
+            $"Morphing layers {LayerIndexStart} through {LayerIndexEnd}";
 
-        public override string ProgressAction => "Morphed layers";
+        public override string ProgressAction => "Morphing layers";
 
         #endregion
 

--- a/UVtools.Core/Operations/OperationMove.cs
+++ b/UVtools.Core/Operations/OperationMove.cs
@@ -16,18 +16,17 @@ namespace UVtools.Core.Operations
     {
         public override string Title => "Move";
         public override string Description =>
-            "Moves the entire model around the build plate.\n" +
-            "Note: Margins are in pixel values.";
+            "Change the position of the model on the build plate.";
 
         public override string ConfirmationText =>
-            $"move model from layers {LayerIndexStart} to {LayerIndexEnd}?\n" +
-            $"From: X:{SrcRoi.X} Y:{SrcRoi.Y}\n" +
-            $"To: X:{DstRoi.X} Y:{DstRoi.Y}";
+            $"move model layers {LayerIndexStart} through {LayerIndexEnd} from " +
+            $"location {{X={SrcRoi.X},Y={SrcRoi.Y}}} to " +
+            $"location {{X={DstRoi.X},Y={DstRoi.Y}}}?";
 
         public override string ProgressTitle =>
-            $"Moving model to X:{DstRoi.X} Y:{DstRoi.Y}";
+            $"Moving model to {{X={DstRoi.X},Y={DstRoi.Y}}}";
 
-        public override string ProgressAction => "Moved layers";
+        public override string ProgressAction => "Moving layers";
 
         public override StringTag Validate(params object[] parameters)
         {
@@ -35,7 +34,7 @@ namespace UVtools.Core.Operations
 
             if (!ValidateBounds())
             {
-                sb.AppendLine("Your parameters will put the object out of build plate, please adjust the margins.");
+                sb.AppendLine("Your parameters will put the model outside of build plate.   Please adjust the location and margins.");
             }
 
             return new StringTag(sb.ToString());

--- a/UVtools.Core/Operations/OperationResize.cs
+++ b/UVtools.Core/Operations/OperationResize.cs
@@ -14,18 +14,20 @@ namespace UVtools.Core.Operations
     {
         public override string Title => "Resize";
         public override string Description =>
-            "Resizes layer images in a X and/or Y factor, starting from 100% value.\n" +
-            "NOTE 1: Build volume bounds are not validated after operation, please ensure scaling stays inside your limits.\n" +
-            "NOTE 2: X and Y are applied to original image, not to the rotated preview (If enabled).";
+            "Resize the model by a percentage in the X/Y plane.\n\n" +
+            "NOTE: This operation is applied based on the original orientation of the layers in the model file. " +
+            "If the image is rotated 90° in the Layer Preview, you will need to compensate by inverting " +
+            "the X and Y values.  The print bounds will also not be validated as part of this operation, so please " +
+            "ensure that the scaling factor does not result in the model being clipped.";
 
         public override string ConfirmationText =>
-            $"resize model from layers {LayerIndexStart} to {LayerIndexEnd}?\n" +
-            $"X:{X}%  Y:{Y}%";
+            $"resize model layers {LayerIndexStart} through {LayerIndexEnd} by " +
+            $"X={X}% and Y={Y}%";
 
         public override string ProgressTitle =>
             $"Resizing from layers {LayerIndexStart} to {LayerIndexEnd} at X:{X}%  Y:{Y}% ";
 
-        public override string ProgressAction => "Reiszed layers";
+        public override string ProgressAction => "Resizing layers";
 
         public override StringTag Validate(params object[] parameters)
         {
@@ -33,7 +35,7 @@ namespace UVtools.Core.Operations
 
             if (X == 100m && Y == 100m)
             {
-                sb.AppendLine("X and Y can't be 100% together.");
+                sb.AppendLine("X and Y can't both be 100%.");
             }
 
             return new StringTag(sb.ToString());

--- a/UVtools.Core/Operations/OperationRotate.cs
+++ b/UVtools.Core/Operations/OperationRotate.cs
@@ -6,23 +6,23 @@
  *  of this license document, but changing it is not allowed.
  */
 
+using System;
+
 namespace UVtools.Core.Operations
 {
     public class OperationRotate : Operation
     {
         public override string Title => "Rotate";
         public override string Description =>
-            "Rotate layer images in a certain angle degrees.\n" +
-            "Positive angle are clockwise (CW)\n" +
-            "Negative angle are counter-clockwise (CCW)";
+            "Rotate the layers of the model.\n";
 
         public override string ConfirmationText =>
-            $"rotate layers {LayerIndexStart} to {LayerIndexEnd} at {AngleDegrees} degrees";
+            $"rotate layers {LayerIndexStart} through {LayerIndexEnd} {(AngleDegrees < 0?"counter-clockwise":"clockwise")} by {Math.Abs(AngleDegrees)}°?";
 
         public override string ProgressTitle =>
-            $"Rotating layers {LayerIndexStart} to {LayerIndexEnd} at {AngleDegrees} degrees";
+            $"Rotating layers {LayerIndexStart} through {LayerIndexEnd} {(AngleDegrees < 0 ? "counter-clockwise" : "clockwise")} by {Math.Abs(AngleDegrees)}°";
 
-        public override string ProgressAction => "Rotated layers";
+        public override string ProgressAction => "Rotating layers";
 
         public decimal AngleDegrees { get; set; }
     }

--- a/UVtools.Core/Operations/OperationSolidify.cs
+++ b/UVtools.Core/Operations/OperationSolidify.cs
@@ -15,16 +15,16 @@ namespace UVtools.Core.Operations
         public override string Title => "Solidify";
 
         public override string Description =>
-            "Solidifies the selected layers, closes all inner holes.\n" +
-            "NOTE: All open areas of the layer that are completely surrounded by pixels will be filled. Please ensure none of the holes in the layer are required before proceeding.";
+            "Solidifies the selected layers, closing all interior holes.\n\n" +
+            "NOTE: All open areas of the layer that are completely surrounded by pixels will be filled. Please ensure that none of the holes in the layer are required before proceeding.";
 
         public override string ConfirmationText =>
-            $"solidify layers from {LayerIndexStart} to {LayerIndexEnd}?";
+            $"solidify layers {LayerIndexStart} through {LayerIndexEnd}?";
 
         public override string ProgressTitle =>
-            $"Solidifying layers from {LayerIndexStart} to {LayerIndexEnd}";
+            $"Solidifying layers {LayerIndexStart} through {LayerIndexEnd}";
 
-        public override string ProgressAction => "Solidified layers";
+        public override string ProgressAction => "Solidifying layers";
 
         #endregion
     }

--- a/UVtools.GUI/Controls/Tools/CtrlToolFlip.Designer.cs
+++ b/UVtools.GUI/Controls/Tools/CtrlToolFlip.Designer.cs
@@ -48,9 +48,11 @@
             this.cbMakeCopy.AutoSize = true;
             this.cbMakeCopy.Location = new System.Drawing.Point(240, 8);
             this.cbMakeCopy.Name = "cbMakeCopy";
-            this.cbMakeCopy.Size = new System.Drawing.Size(104, 24);
+            this.cbMakeCopy.Size = new System.Drawing.Size(120, 24);
             this.cbMakeCopy.TabIndex = 22;
-            this.cbMakeCopy.Text = "Make copy";
+            this.cbMakeCopy.Text = "Blend Layers";
+            this.toolTip.SetToolTip(this.cbMakeCopy, "If checked, rather than simply flipping the layer, a copy of each layer will be f" +
+        "lipped and blended with the layer.");
             this.cbMakeCopy.UseVisualStyleBackColor = true;
             // 
             // cbFlipDirection
@@ -73,7 +75,7 @@
             this.Description = "";
             this.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Name = "CtrlToolFlip";
-            this.Size = new System.Drawing.Size(540, 45);
+            this.Size = new System.Drawing.Size(720, 45);
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/UVtools.GUI/Controls/Tools/CtrlToolMove.Designer.cs
+++ b/UVtools.GUI/Controls/Tools/CtrlToolMove.Designer.cs
@@ -79,15 +79,15 @@
             this.groupBox1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.groupBox1.Location = new System.Drawing.Point(0, 0);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(571, 210);
+            this.groupBox1.Size = new System.Drawing.Size(720, 210);
             this.groupBox1.TabIndex = 24;
             this.groupBox1.TabStop = false;
-            this.groupBox1.Text = "Margins and Anchor";
+            this.groupBox1.Text = "Location && Margins";
             // 
             // lbInsideBounds
             // 
             this.lbInsideBounds.AutoSize = true;
-            this.lbInsideBounds.Location = new System.Drawing.Point(7, 168);
+            this.lbInsideBounds.Location = new System.Drawing.Point(7, 172);
             this.lbInsideBounds.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lbInsideBounds.Name = "lbInsideBounds";
             this.lbInsideBounds.Size = new System.Drawing.Size(147, 20);
@@ -97,42 +97,42 @@
             // lbPlacementY
             // 
             this.lbPlacementY.AutoSize = true;
-            this.lbPlacementY.Location = new System.Drawing.Point(7, 138);
+            this.lbPlacementY.Location = new System.Drawing.Point(7, 60);
             this.lbPlacementY.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lbPlacementY.Name = "lbPlacementY";
-            this.lbPlacementY.Size = new System.Drawing.Size(103, 20);
+            this.lbPlacementY.Size = new System.Drawing.Size(24, 20);
             this.lbPlacementY.TabIndex = 26;
-            this.lbPlacementY.Text = "Placement Y:";
+            this.lbPlacementY.Text = "Y:";
             // 
             // lbPlacementX
             // 
             this.lbPlacementX.AutoSize = true;
-            this.lbPlacementX.Location = new System.Drawing.Point(7, 107);
+            this.lbPlacementX.Location = new System.Drawing.Point(7, 31);
             this.lbPlacementX.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lbPlacementX.Name = "lbPlacementX";
-            this.lbPlacementX.Size = new System.Drawing.Size(103, 20);
+            this.lbPlacementX.Size = new System.Drawing.Size(24, 20);
             this.lbPlacementX.TabIndex = 25;
-            this.lbPlacementX.Text = "Placement X:";
+            this.lbPlacementX.Text = "X:";
             // 
             // lbVolumeHeight
             // 
             this.lbVolumeHeight.AutoSize = true;
-            this.lbVolumeHeight.Location = new System.Drawing.Point(7, 56);
+            this.lbVolumeHeight.Location = new System.Drawing.Point(7, 134);
             this.lbVolumeHeight.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lbVolumeHeight.Name = "lbVolumeHeight";
-            this.lbVolumeHeight.Size = new System.Drawing.Size(118, 20);
+            this.lbVolumeHeight.Size = new System.Drawing.Size(60, 20);
             this.lbVolumeHeight.TabIndex = 24;
-            this.lbVolumeHeight.Text = "Volume Height:";
+            this.lbVolumeHeight.Text = "Height:";
             // 
             // lbVolumeWidth
             // 
             this.lbVolumeWidth.AutoSize = true;
-            this.lbVolumeWidth.Location = new System.Drawing.Point(7, 27);
+            this.lbVolumeWidth.Location = new System.Drawing.Point(7, 103);
             this.lbVolumeWidth.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lbVolumeWidth.Name = "lbVolumeWidth";
-            this.lbVolumeWidth.Size = new System.Drawing.Size(112, 20);
+            this.lbVolumeWidth.Size = new System.Drawing.Size(54, 20);
             this.lbVolumeWidth.TabIndex = 23;
-            this.lbVolumeWidth.Text = "Volume Width:";
+            this.lbVolumeWidth.Text = "Width:";
             // 
             // label5
             // 
@@ -288,7 +288,9 @@
             this.nmMarginTop.Size = new System.Drawing.Size(85, 26);
             this.nmMarginTop.TabIndex = 15;
             this.nmMarginTop.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this.toolTip.SetToolTip(this.nmMarginTop, "Top margin in pixels");
             this.nmMarginTop.ValueChanged += new System.EventHandler(this.EventValueChanged);
+            this.nmMarginTop.KeyUp += new System.Windows.Forms.KeyEventHandler(this.EventValueChanged);
             // 
             // nmMarginBottom
             // 
@@ -307,7 +309,9 @@
             this.nmMarginBottom.Size = new System.Drawing.Size(85, 26);
             this.nmMarginBottom.TabIndex = 17;
             this.nmMarginBottom.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this.toolTip.SetToolTip(this.nmMarginBottom, "Bottom margin in pixels");
             this.nmMarginBottom.ValueChanged += new System.EventHandler(this.EventValueChanged);
+            this.nmMarginBottom.KeyUp += new System.Windows.Forms.KeyEventHandler(this.EventValueChanged);
             // 
             // label3
             // 
@@ -356,7 +360,9 @@
             this.nmMarginRight.Size = new System.Drawing.Size(85, 26);
             this.nmMarginRight.TabIndex = 19;
             this.nmMarginRight.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+            this.toolTip.SetToolTip(this.nmMarginRight, "Right margin in pixels");
             this.nmMarginRight.ValueChanged += new System.EventHandler(this.EventValueChanged);
+            this.nmMarginRight.KeyUp += new System.Windows.Forms.KeyEventHandler(this.EventValueChanged);
             // 
             // nmMarginLeft
             // 
@@ -374,10 +380,12 @@
             this.nmMarginLeft.Name = "nmMarginLeft";
             this.nmMarginLeft.Size = new System.Drawing.Size(85, 26);
             this.nmMarginLeft.TabIndex = 20;
+            this.toolTip.SetToolTip(this.nmMarginLeft, "Left Margin in pixels");
             this.nmMarginLeft.UpDownAlign = System.Windows.Forms.LeftRightAlignment.Left;
             this.nmMarginLeft.ValueChanged += new System.EventHandler(this.EventValueChanged);
+            this.nmMarginLeft.KeyUp += new System.Windows.Forms.KeyEventHandler(this.EventValueChanged);
             // 
-            // CtrlToolMoveModel
+            // CtrlToolMove
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
@@ -387,7 +395,7 @@
             this.Description = "";
             this.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Name = "CtrlToolMove";
-            this.Size = new System.Drawing.Size(571, 210);
+            this.Size = new System.Drawing.Size(720, 210);
             this.groupBox1.ResumeLayout(false);
             this.groupBox1.PerformLayout();
             this.tableAnchor.ResumeLayout(false);

--- a/UVtools.GUI/Controls/Tools/CtrlToolMove.cs
+++ b/UVtools.GUI/Controls/Tools/CtrlToolMove.cs
@@ -24,8 +24,8 @@ namespace UVtools.GUI.Controls.Tools
                 (uint)Program.FrmMain.ActualLayerImage.Height);
             SetOperation(Operation);
 
-            lbVolumeWidth.Text = $"Volume Width: {Operation.SrcRoi.Width} / {Operation.ImageWidth}";
-            lbVolumeHeight.Text = $"Volume Height: {Operation.SrcRoi.Height} / {Operation.ImageHeight}";
+            lbVolumeWidth.Text = $"Width: {Operation.SrcRoi.Width} / {Operation.ImageWidth}";
+            lbVolumeHeight.Text = $"Height: {Operation.SrcRoi.Height} / {Operation.ImageHeight}";
 
             ResetDefaults();
         }
@@ -44,9 +44,9 @@ namespace UVtools.GUI.Controls.Tools
         {
             UpdateOperation();
             var insideBounds = ButtonOkEnabled = Operation.ValidateBounds();
-            lbInsideBounds.Text = "Inside Bounds: " + (insideBounds ? "Yes" : "No");
-            lbPlacementX.Text = $"Placement X: {Operation.DstRoi.X} / {Operation.ImageWidth - Operation.SrcRoi.Width}";
-            lbPlacementY.Text = $"Placement Y: {Operation.DstRoi.Y} / {Operation.ImageHeight - Operation.SrcRoi.Height}";
+            lbInsideBounds.Text = "Model within boundary: " + (insideBounds ? "Yes" : "No");
+            lbPlacementX.Text = $"X: {Operation.DstRoi.X} / {Operation.ImageWidth - Operation.SrcRoi.Width}";
+            lbPlacementY.Text = $"Y: {Operation.DstRoi.Y} / {Operation.ImageHeight - Operation.SrcRoi.Height}";
         }
 
         public override bool UpdateOperation()

--- a/UVtools.GUI/Controls/Tools/CtrlToolResize.Designer.cs
+++ b/UVtools.GUI/Controls/Tools/CtrlToolResize.Designer.cs
@@ -46,9 +46,12 @@
             this.cbFade.AutoSize = true;
             this.cbFade.Location = new System.Drawing.Point(8, 41);
             this.cbFade.Name = "cbFade";
-            this.cbFade.Size = new System.Drawing.Size(170, 24);
+            this.cbFade.Size = new System.Drawing.Size(283, 24);
             this.cbFade.TabIndex = 26;
-            this.cbFade.Text = "Fade towards 100%";
+            this.cbFade.Text = "Increase or decrease towards 100%";
+            this.toolTip.SetToolTip(this.cbFade, "If checked, resize will gradually adjust the scale factor from the percentage spe" +
+        "cified to 100% as the operation progresses from the starting layer to the ending" +
+        " layer.");
             this.cbFade.UseVisualStyleBackColor = true;
             // 
             // label2
@@ -80,9 +83,9 @@
             this.cbConstrainXY.CheckState = System.Windows.Forms.CheckState.Checked;
             this.cbConstrainXY.Location = new System.Drawing.Point(388, 8);
             this.cbConstrainXY.Name = "cbConstrainXY";
-            this.cbConstrainXY.Size = new System.Drawing.Size(126, 24);
+            this.cbConstrainXY.Size = new System.Drawing.Size(181, 24);
             this.cbConstrainXY.TabIndex = 23;
-            this.cbConstrainXY.Text = "Constrain X/Y";
+            this.cbConstrainXY.Text = "Constrain Proportions";
             this.cbConstrainXY.CheckedChanged += new System.EventHandler(this.EventValueChanged);
             // 
             // nmY
@@ -174,7 +177,7 @@
             this.Description = "";
             this.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Name = "CtrlToolResize";
-            this.Size = new System.Drawing.Size(540, 77);
+            this.Size = new System.Drawing.Size(720, 77);
             ((System.ComponentModel.ISupportInitialize)(this.nmY)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nmX)).EndInit();
             this.ResumeLayout(false);

--- a/UVtools.GUI/Controls/Tools/CtrlToolRotate.Designer.cs
+++ b/UVtools.GUI/Controls/Tools/CtrlToolRotate.Designer.cs
@@ -52,6 +52,8 @@
             this.nmDegrees.Name = "nmDegrees";
             this.nmDegrees.Size = new System.Drawing.Size(101, 26);
             this.nmDegrees.TabIndex = 23;
+            this.toolTip.SetToolTip(this.nmDegrees, "Number of degrees to rotate the layers, where postive values are clockwise and ne" +
+        "gative values are counter-clockwise.");
             this.nmDegrees.Value = new decimal(new int[] {
             90,
             0,
@@ -91,6 +93,7 @@
             this.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Name = "CtrlToolRotate";
             this.Size = new System.Drawing.Size(540, 45);
+            this.toolTip.SetToolTip(this, "  ");
             ((System.ComponentModel.ISupportInitialize)(this.nmDegrees)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();


### PR DESCRIPTION
-Update the operation text and some of the dialog text for both move and resize.

-Added Key-up event to trigger validate for the NumericUpDown margin boxes in the move operation so that values are validated as entered, rather than only when focus is lost.  This addresses an issue where you can enter a value that pushes the model out of bounds, but it's not actually validated until focus when the "Move" button is actually pressed.  With this change, "Move" will be disabled before it can be pressed.