### PR TITLE
Refresh of text for all operations

### DIFF
--- a/UVtools.Core/Operations/OperationBlur.cs
+++ b/UVtools.Core/Operations/OperationBlur.cs
@@ -17,15 +17,15 @@ namespace UVtools.Core.Operations
 
         public override string Title => "Blur";
         public override string Description =>
-            $"Blur and averaging images with various low pass filters\n" +
-            "Note: Printer must support AntiAliasing on firmware to able to use this function\n" +
-            "More information: https://docs.opencv.org/master/d4/d13/tutorial_py_filtering.html";
+            $"Blur layer images by applying a low pass filter\n\n" +
+            "NOTE: Target printer must support AntiAliasing in order to use this function.\n\n" +
+            "See https://docs.opencv.org/master/d4/d13/tutorial_py_filtering.html";
 
         public override string ConfirmationText =>
-            $"blur model with {BlurOperation} from layers {LayerIndexStart} to {LayerIndexEnd}?";
+            $"blur model with {BlurOperation} from layers {LayerIndexStart} through {LayerIndexEnd}?";
 
         public override string ProgressTitle =>
-            $"Bluring model with {BlurOperation} layers from {LayerIndexStart} to {LayerIndexEnd}";
+            $"Bluring model with {BlurOperation} from layers {LayerIndexStart} through {LayerIndexEnd}";
 
         public override string ProgressAction => "Blured layers";
 
@@ -46,7 +46,7 @@ namespace UVtools.Core.Operations
             {
                 if (Kernel is null)
                 {
-                    sb.AppendLine("Kernel can't be empty.");
+                    sb.AppendLine("Kernel can not be empty.");
                 }
             }
 

--- a/UVtools.Core/Operations/OperationChangeResolution.cs
+++ b/UVtools.Core/Operations/OperationChangeResolution.cs
@@ -43,17 +43,17 @@ namespace UVtools.Core.Operations
 
         public override string Title => "Change print resolution";
         public override string Description =>
-            "Crops or resizes all layer images to fit an alternate print area\n" +
-            "Useful to make files printable on a different printer than they were originally sliced for without the need to re-slice.\n" +
-            "NOTE: Please ensure that the actual object will fit within the new print resolution. The operation will be aborted if it will result in any of the actual model being clipped.";
+            "Crops or resizes all layer images to fit an alternate print area\n\n" +
+            "Useful to make files printable on a different printer than they were originally sliced for without the need to re-slice.\n\n" +
+            "NOTE: Please ensure that the actual model will fit within the new print resolution. The operation will be aborted if it will result in any of the actual model being clipped.";
 
         public override string ConfirmationText => 
-            "change file resolution?\n" +
-            $"From: {OldResolution.Width} x {OldResolution.Height}\n" +
-            $"To: {NewResolutionX} x {NewResolutionY}";
+            "change print resolution " +
+            $"from {OldResolution.Width}x{OldResolution.Height} " +
+            $"to {NewResolutionX}x{NewResolutionY}?";
 
         public override string ProgressTitle =>
-            $"Changing print resolution from ({OldResolution.Width} x {OldResolution.Height}) to ({NewResolutionX} x {NewResolutionY})";
+            $"Changing print resolution from ({OldResolution.Width}x{OldResolution.Height}) to ({NewResolutionX}x{NewResolutionY})";
 
         public override string ProgressAction => "Changed layers";
 
@@ -67,7 +67,7 @@ namespace UVtools.Core.Operations
 
             if (NewResolutionX < VolumeBonds.Width || NewResolutionY < VolumeBonds.Height)
             {
-                sb.AppendLine($"The new resolution ({NewResolutionX} x {NewResolutionY}) is not enough to accommodate the object volume ({VolumeBonds.Width} x {VolumeBonds.Height}), continuing operation would cut the object");
+                sb.AppendLine($"The new resolution ({NewResolutionX} x {NewResolutionY}) is not large enough to hold the model volume ({VolumeBonds.Width} x {VolumeBonds.Height}), continuing operation would clip the model");
                 sb.AppendLine("To fix this, try to rotate the object and/or resize to fit on this new resolution.");
             }
 

--- a/UVtools.Core/Operations/OperationFlip.cs
+++ b/UVtools.Core/Operations/OperationFlip.cs
@@ -14,13 +14,17 @@ namespace UVtools.Core.Operations
     {
         public override string Title => "Flip";
         public override string Description =>
-            "Flips layer images vertically and/or horizontally.";
+            "Flip the layers of the model vertically and/or horizontally.";
 
         public override string ConfirmationText =>
-            $"flip {FlipDirection} from layers {LayerIndexStart} to {LayerIndexEnd}";
+            FlipDirection == Enumerations.FlipDirection.Both
+                ? $"flip {(MakeCopy == true? "and blend ":"")}layers {LayerIndexStart} through {LayerIndexEnd} Horizontally and Vertically?"
+                : $"flip {(MakeCopy == true ? "and blend " : "")}layers {LayerIndexStart} through {LayerIndexEnd} {FlipDirection}?";
 
         public override string ProgressTitle =>
-            $"Flipping {FlipDirection} from layers {LayerIndexStart} to {LayerIndexEnd}";
+            FlipDirection == Enumerations.FlipDirection.Both
+                ? $"Flipping {(MakeCopy == true ? "and blending " : "")}layers {LayerIndexStart} through {LayerIndexEnd} Horizontally and Vertically"
+                : $"Flipping {(MakeCopy == true ? "and blending " : "")}layers {LayerIndexStart} through {LayerIndexEnd} {FlipDirection}";
 
         public override string ProgressAction => "Flipped layers";
         

--- a/UVtools.Core/Operations/OperationLayerClone.cs
+++ b/UVtools.Core/Operations/OperationLayerClone.cs
@@ -18,13 +18,13 @@ namespace UVtools.Core.Operations
 
         public override string Title => "Clone layer(s)";
         public override string Description =>
-            "Clone layers.\n" +
+            "Clone layers.\n\n" +
             "Useful to increase the height of the model or add additional structure by duplicating layers. For example, can be used to increase the raft height for added stability.";
         public override string ConfirmationText =>
-            $"clone layers from {LayerIndexStart} to {LayerIndexEnd} times {Clones} clones?";
+            $"clone layers {LayerIndexStart} through {LayerIndexEnd}, {Clones} time{(Clones != 1 ? "s" : "")}?";
 
         public override string ProgressTitle =>
-            $"Cloning layers from {LayerIndexStart} to {LayerIndexEnd} times {Clones} clones";
+            $"Cloning layers {LayerIndexStart} through {LayerIndexEnd}, {Clones} time{(Clones != 1 ? "s" : "")}";
 
         public override string ProgressAction => "Cloned layers";
 

--- a/UVtools.Core/Operations/OperationLayerImport.cs
+++ b/UVtools.Core/Operations/OperationLayerImport.cs
@@ -21,16 +21,16 @@ namespace UVtools.Core.Operations
     public sealed class OperationLayerImport : Operation
     {
         #region Overrides
-        public override string Title => "Import Layer(s)";
+        public override string Title => "Import Layers";
 
         public override string Description =>
-            "Import layer(s) from local file(s) into the model at a selected height.\n" +
-            "NOTE: Images must respect file resolution and in greyscale color.";
+            "Import layers from local files into the model at a selected layer height.\n\n" +
+            "NOTE: Imported images must be greyscale and have the same resolution as the model.";
 
-        public override string ConfirmationText => $"import {Count} layer(s)?";
+        public override string ConfirmationText => $"import {Count} layer{(Count!=1?"s":"")}?";
 
         public override string ProgressTitle =>
-            $"Importing {Count} layer(s)";
+            $"Importing {Count} layer{(Count!=1 ? "s" : "")}";
 
         public override string ProgressAction => "Imported layers";
 
@@ -53,7 +53,7 @@ namespace UVtools.Core.Operations
 
             if (result.IsEmpty) return null;
             var message = new StringBuilder();
-            message.AppendLine($"The following {result.Count} files mismatched the slice resolution of {FileResolution.Width} x {FileResolution.Height}:");
+            message.AppendLine($"The following {result.Count} files mismatched the target resolution of {FileResolution.Width}x{FileResolution.Height}:");
             message.AppendLine();
             uint count = 0;
             foreach (var file in result)
@@ -61,7 +61,7 @@ namespace UVtools.Core.Operations
                 count++;
                 if (count == 20)
                 {
-                    message.AppendLine("... To many to show ...");
+                    message.AppendLine("... Too many to show ...");
                     break;
                 }
                 message.AppendLine(Path.GetFileNameWithoutExtension(file));

--- a/UVtools.Core/Operations/OperationLayerReHeight.cs
+++ b/UVtools.Core/Operations/OperationLayerReHeight.cs
@@ -18,19 +18,19 @@ namespace UVtools.Core.Operations
     {
         #region Overrides
 
-        public override string Title => "Layer re-height";
+        public override string Title => "Adjust layer height";
         public override string Description =>
-            "Changes layer height.\n" +
-            "Going lower doesn't give you better XYZ accuracy but will reduce Z lines, layers will be cloned and repeated over Z for the effect.\n" +
-            "Going higher will reduce detail, layers will sum times the modifier for the effect.\n" +
-            "Note: Reslice with the new layer height is always preferable";
+            "Adjust the layer height of the model\n\n" +
+            "Adjusting to values lower than current height will reduce layer lines, adjusting to values higher" +
+            " than current height will reduce model detail.\n\n" +
+            "Note: Using dedicated slicer software to re-slice will usually yeild better results.";
         public override string ConfirmationText =>
-            $"re-height layers to {Item.LayerHeight}mm?";
+            $"adjust layer height to {Item.LayerHeight}mm?";
 
         public override string ProgressTitle =>
-            $"Re-height layers to {Item.LayerHeight}mm";
+            $"Adjusting layer height to {Item.LayerHeight}mm";
 
-        public override string ProgressAction => "Re-height-ed layers";
+        public override string ProgressAction => "Height adjusted layers";
 
         public override StringTag Validate(params object[] parameters)
         {
@@ -38,7 +38,7 @@ namespace UVtools.Core.Operations
 
             if (Item is null)
             {
-                sb.AppendLine("No valid configurations to proceed");
+                sb.AppendLine("No valid configurations, unable to proceed.");
             }
 
 

--- a/UVtools.Core/Operations/OperationLayerRemove.cs
+++ b/UVtools.Core/Operations/OperationLayerRemove.cs
@@ -15,16 +15,16 @@ namespace UVtools.Core.Operations
 
         public override bool PassActualLayerIndex => true;
 
-        public override string Title => "Remove layer(s)";
+        public override string Title => "Remove layers";
 
         public override string Description =>
-            "Remove Layer(s) in a given range.";
+            "Remove Layers in a given range.";
 
         public override string ConfirmationText =>
-            $"remove layers from {LayerIndexStart} to {LayerIndexEnd}?";
+            $"remove layers {LayerIndexStart} through {LayerIndexEnd}?";
 
         public override string ProgressTitle =>
-            $"Removing layers from {LayerIndexStart} to {LayerIndexEnd}";
+            $"Removing layers {LayerIndexStart} through {LayerIndexEnd}";
 
         public override string ProgressAction => "Removed layers";
 

--- a/UVtools.Core/Operations/OperationMask.cs
+++ b/UVtools.Core/Operations/OperationMask.cs
@@ -17,16 +17,16 @@ namespace UVtools.Core.Operations
     {
         public override string Title => "Mask";
         public override string Description =>
-            "Masks the LCD output image given a greyscale (0-255) pixel input image.\n" +
-            "Useful to correct light uniformity, but a proper mask must be created first based on real measurements per printer.\n" +
-            "NOTE 1: Masks should respect printer resolution or they will be resized to fit.\n" +
-            "NOTE 2: Run only this tool after all repairs and other transformations.";
+            "Mask the intensity of the LCD output using a greyscale input image.\n\n" +
+            "Useful to correct LCD light uniformity for a specific printer.\n\n" +
+            "NOTE:  This operation should be run only after repairs and other transformations.  The provided" +
+            "input mask image must match the ouput resolution of the target printer.";
 
         public override string ConfirmationText =>
-            $"mask layers from {LayerIndexStart} to {LayerIndexEnd}";
+            $"mask layers from {LayerIndexStart} through {LayerIndexEnd}";
 
         public override string ProgressTitle =>
-            $"Masking layers from {LayerIndexStart} to {LayerIndexEnd}";
+            $"Masking layers from {LayerIndexStart} through {LayerIndexEnd}";
 
         public override string ProgressAction => "Masked layers";
 
@@ -35,7 +35,7 @@ namespace UVtools.Core.Operations
             var sb = new StringBuilder();
             if (Mask is null)
             {
-                sb.AppendLine("The mask can't be empty.");
+                sb.AppendLine("The mask can not be empty.");
             }
 
             return new StringTag(sb.ToString());

--- a/UVtools.Core/Operations/OperationMorph.cs
+++ b/UVtools.Core/Operations/OperationMorph.cs
@@ -17,13 +17,13 @@ namespace UVtools.Core.Operations
 
         public override string Title => "Morph";
         public override string Description =>
-            $"Morph Model\n" +
-            $"Various operations that can be used to change the physical structure of the model or individual layers in various ways.";
+            $"Morph Model - " +
+            $"Various operations that can be used to change the physical structure of the model or individual layers.";
         public override string ConfirmationText =>
-            $"morph model from layers {LayerIndexStart} to {LayerIndexEnd}?";
+            $"morph model layers {LayerIndexStart} through {LayerIndexEnd}?";
 
         public override string ProgressTitle =>
-            $"Morphing layers from {LayerIndexStart} to {LayerIndexEnd}";
+            $"Morphing layers {LayerIndexStart} through {LayerIndexEnd}";
 
         public override string ProgressAction => "Morphed layers";
 

--- a/UVtools.Core/Operations/OperationMove.cs
+++ b/UVtools.Core/Operations/OperationMove.cs
@@ -16,16 +16,15 @@ namespace UVtools.Core.Operations
     {
         public override string Title => "Move";
         public override string Description =>
-            "Moves the entire model around the build plate.\n" +
-            "Note: Margins are in pixel values.";
+            "Change the position of the model on the build plate.";
 
         public override string ConfirmationText =>
-            $"move model from layers {LayerIndexStart} to {LayerIndexEnd}?\n" +
-            $"From: X:{SrcRoi.X} Y:{SrcRoi.Y}\n" +
-            $"To: X:{DstRoi.X} Y:{DstRoi.Y}";
+            $"move model layers {LayerIndexStart} through {LayerIndexEnd} from " +
+            $"location {{X={SrcRoi.X},Y={SrcRoi.Y}}} to " +
+            $"location {{X={DstRoi.X},Y={DstRoi.Y}}}?";
 
         public override string ProgressTitle =>
-            $"Moving model to X:{DstRoi.X} Y:{DstRoi.Y}";
+            $"Moving model to {{X={DstRoi.X},Y={DstRoi.Y}}}";
 
         public override string ProgressAction => "Moved layers";
 
@@ -35,7 +34,7 @@ namespace UVtools.Core.Operations
 
             if (!ValidateBounds())
             {
-                sb.AppendLine("Your parameters will put the object out of build plate, please adjust the margins.");
+                sb.AppendLine("Your parameters will put the model outside of build plate.   Please adjust the location and margins.");
             }
 
             return new StringTag(sb.ToString());

--- a/UVtools.Core/Operations/OperationPattern.cs
+++ b/UVtools.Core/Operations/OperationPattern.cs
@@ -15,14 +15,14 @@ namespace UVtools.Core.Operations
     {
         #region Overrides
 
-        public override string Title => "Pattern";
+        public override string Title => "Duplicate";
         public override string Description =>
-            "Rectangular pattern the print around the plate.";
+            "Duplicates the model in a rectangular pattern around the build plate.";
         public override string ConfirmationText =>
-            $"pattern the object with {Cols} x {Rows} copies?";
+            $"duplicate the object across {Cols} columns and {Rows} rows?";
 
         public override string ProgressTitle =>
-            $"Pattern the object with {Cols} x {Rows} copies";
+            $"Duplicating the object across {Cols} columns and {Rows} rowss";
 
         public override string ProgressAction => "Patterned layers";
 
@@ -32,12 +32,12 @@ namespace UVtools.Core.Operations
 
             if (Cols <= 1 && Rows <= 1)
             {
-                sb.AppendLine("Either columns or rows must be greater than 1 to be able to run this tool.");
+                sb.AppendLine("Either columns or rows must be greater than 1.");
             }
             
             if (!ValidateBounds())
             {
-                sb.AppendLine("Your parameters will put the object out of build plate, please adjust the margins.");
+                sb.AppendLine("Your parameters will put the object outside of the build plate, please adjust the margins.");
             }
 
             return new StringTag(sb.ToString());

--- a/UVtools.Core/Operations/OperationPixelDimming.cs
+++ b/UVtools.Core/Operations/OperationPixelDimming.cs
@@ -17,17 +17,18 @@ namespace UVtools.Core.Operations
         #region Overrides
         public override string Title => "Pixel dimming";
         public override string Description =>
-            "Dims pixels in a chosen pattern over white pixels neighborhood. The selected pattern will be repeated over the image width and height as a mask. Benefits are:\n" +
-            "1) Reduce layer expansion in big masses\n" +
-            "2) Reduce cross layer exposure\n" +
-            "3) Extend pixels life\n" +
-            "NOTE: Run only this tool after all repairs and other transformations.";
+            "Dim white pixels in a chosen pattern applied over the print area.\n\n" +
+            "The selected pattern will tiled over the image.  Benefits are:\n" +
+            "1) Reduced layer expansion for large layer objects\n" +
+            "2) Reduced cross layer exposure\n" +
+            "3) Extended pixel life of the LCD\n\n" +
+            "NOTE: Run this tool only after repairs and all other transformations.";
 
         public override string ConfirmationText =>
-            $"dim pixels from layers {LayerIndexStart} to {LayerIndexEnd}";
+            $"dim pixels from layers {LayerIndexStart} through {LayerIndexEnd}";
 
         public override string ProgressTitle =>
-            $"Dimming from layers {LayerIndexStart} to {LayerIndexEnd}";
+            $"Dimming from layers {LayerIndexStart} through {LayerIndexEnd}";
 
         public override string ProgressAction => "Dimmed layers";
 
@@ -36,7 +37,7 @@ namespace UVtools.Core.Operations
             var sb = new StringBuilder();
             if (BorderSize == 0 && BordersOnly)
             {
-                sb.AppendLine("Border size must be positive in order to use \"Dims only the borders\" function.");
+                sb.AppendLine("Border size must be positive in order to use \"Dim only borders\" function.");
             }
 
             if (EvenPattern is null && OddPattern is null)

--- a/UVtools.Core/Operations/OperationProgress.cs
+++ b/UVtools.Core/Operations/OperationProgress.cs
@@ -12,10 +12,10 @@ namespace UVtools.Core.Operations
 {
     public sealed class OperationProgress
     {
-        public const string StatusDecodeThumbnails = "Decoding Thumbnails";
-        public const string StatusGatherLayers = "Gathering Layers";
-        public const string StatusDecodeLayers = "Decoding Layers";
-        public const string StatusEncodeLayers = "Encoding Layers";
+        public const string StatusDecodeThumbnails = "Decoded Thumbnails";
+        public const string StatusGatherLayers = "Gathered Layers";
+        public const string StatusDecodeLayers = "Decoded Layers";
+        public const string StatusEncodeLayers = "Encoded Layers";
         public const string StatusWritingFile = "Writing File";
         public const string StatusEncodeGcode = "Encoding GCode";
 
@@ -24,9 +24,9 @@ namespace UVtools.Core.Operations
 
         public const string StatusExtracting = "Extracting";
 
-        public const string StatusIslands = "Islands";
-        public const string StatusResinTraps = "Resin traps";
-        public const string StatusRepairLayers = "Repair Layers";
+        public const string StatusIslands = "Layers processed (Islands)";
+        public const string StatusResinTraps = "Layers processed (Resin traps)";
+        public const string StatusRepairLayers = "Repaired Layers";
 
         public object Mutex = new object();
 
@@ -113,8 +113,8 @@ namespace UVtools.Core.Operations
         public override string ToString()
         {
             return ItemCount == 0 ?
-                $"{ProcessedItems} / ? {ItemName}" :
-                $"{RemainingItems} / {ItemCount} / {ProcessedItems} | {ItemName} | {ProgressPercent:0.00}%";
+                $"{ProcessedItems}/? {ItemName}" :
+                $"{ProcessedItems}/{ItemCount} {ItemName} - {ProgressPercent:0.00}%";
         }
     }
 }

--- a/UVtools.Core/Operations/OperationRepairLayers.cs
+++ b/UVtools.Core/Operations/OperationRepairLayers.cs
@@ -20,7 +20,7 @@ namespace UVtools.Core.Operations
         public override string ConfirmationText => "attempt  this repair?";
 
         public override string ProgressTitle =>
-            $"Reparing layers from layers {LayerIndexStart} to {LayerIndexEnd}";
+            $"Reparing layers {LayerIndexStart} through {LayerIndexEnd}";
 
         public override string ProgressAction => "Repaired layers";
 

--- a/UVtools.Core/Operations/OperationResize.cs
+++ b/UVtools.Core/Operations/OperationResize.cs
@@ -14,13 +14,15 @@ namespace UVtools.Core.Operations
     {
         public override string Title => "Resize";
         public override string Description =>
-            "Resizes layer images in a X and/or Y factor, starting from 100% value.\n" +
-            "NOTE 1: Build volume bounds are not validated after operation, please ensure scaling stays inside your limits.\n" +
-            "NOTE 2: X and Y are applied to original image, not to the rotated preview (If enabled).";
+            "Resize the model by a percentage in the X/Y plane.\n\n" +
+            "NOTE: This operation is applied based on the original orientation of the layers in the model file. " +
+            "If the image is rotated 90° in the Layer Preview, you will need to compensate by inverting " +
+            "the X and Y values.  The print bounds will also not be validated as part of this operation, so please " +
+            "ensure that the scaling factor does not result in the model being clipped.";
 
         public override string ConfirmationText =>
-            $"resize model from layers {LayerIndexStart} to {LayerIndexEnd}?\n" +
-            $"X:{X}%  Y:{Y}%";
+            $"resize model layers {LayerIndexStart} through {LayerIndexEnd} by " +
+            $"X={X}% and Y={Y}%";
 
         public override string ProgressTitle =>
             $"Resizing from layers {LayerIndexStart} to {LayerIndexEnd} at X:{X}%  Y:{Y}% ";
@@ -33,7 +35,7 @@ namespace UVtools.Core.Operations
 
             if (X == 100m && Y == 100m)
             {
-                sb.AppendLine("X and Y can't be 100% together.");
+                sb.AppendLine("X and Y can't both be 100%.");
             }
 
             return new StringTag(sb.ToString());

--- a/UVtools.Core/Operations/OperationRotate.cs
+++ b/UVtools.Core/Operations/OperationRotate.cs
@@ -6,21 +6,21 @@
  *  of this license document, but changing it is not allowed.
  */
 
+using System;
+
 namespace UVtools.Core.Operations
 {
     public class OperationRotate : Operation
     {
         public override string Title => "Rotate";
         public override string Description =>
-            "Rotate layer images in a certain angle degrees.\n" +
-            "Positive angle are clockwise (CW)\n" +
-            "Negative angle are counter-clockwise (CCW)";
+            "Rotate the layers of the model.\n";
 
         public override string ConfirmationText =>
-            $"rotate layers {LayerIndexStart} to {LayerIndexEnd} at {AngleDegrees} degrees";
+            $"rotate layers {LayerIndexStart} through {LayerIndexEnd} {(AngleDegrees < 0?"counter-clockwise":"clockwise")} by {Math.Abs(AngleDegrees)}°?";
 
         public override string ProgressTitle =>
-            $"Rotating layers {LayerIndexStart} to {LayerIndexEnd} at {AngleDegrees} degrees";
+            $"Rotating layers {LayerIndexStart} through {LayerIndexEnd} {(AngleDegrees < 0 ? "counter-clockwise" : "clockwise")} by {Math.Abs(AngleDegrees)}°";
 
         public override string ProgressAction => "Rotated layers";
 

--- a/UVtools.Core/Operations/OperationSolidify.cs
+++ b/UVtools.Core/Operations/OperationSolidify.cs
@@ -15,14 +15,14 @@ namespace UVtools.Core.Operations
         public override string Title => "Solidify";
 
         public override string Description =>
-            "Solidifies the selected layers, closes all inner holes.\n" +
-            "NOTE: All open areas of the layer that are completely surrounded by pixels will be filled. Please ensure none of the holes in the layer are required before proceeding.";
+            "Solidifies the selected layers, closing all interior holes.\n\n" +
+            "NOTE: All open areas of the layer that are completely surrounded by pixels will be filled. Please ensure that none of the holes in the layer are required before proceeding.";
 
         public override string ConfirmationText =>
-            $"solidify layers from {LayerIndexStart} to {LayerIndexEnd}?";
+            $"solidify layers {LayerIndexStart} through {LayerIndexEnd}?";
 
         public override string ProgressTitle =>
-            $"Solidifying layers from {LayerIndexStart} to {LayerIndexEnd}";
+            $"Solidifying layers {LayerIndexStart} through {LayerIndexEnd}";
 
         public override string ProgressAction => "Solidified layers";
 

--- a/UVtools.Core/Operations/OperationThreshold.cs
+++ b/UVtools.Core/Operations/OperationThreshold.cs
@@ -14,15 +14,16 @@ namespace UVtools.Core.Operations
     {
         public override string Title => "Threshold pixels";
         public override string Description =>
-            "Manipulates pixels values giving a threshold, maximum and a operation type.\n" +
-            "If a pixel brightness is less or equal to the threshold value, set this pixel to 0, otherwise set to defined maximum value.\n" +
-            "More info: https://docs.opencv.org/master/d7/d4d/tutorial_py_thresholding.html";
+            "Manipulate pixel values based on a threshold.\n\n" +
+            "Pixles brighter than the theshold will be set to the Max value, " +
+            "all other pixels will be set to 0.\n\n" +
+            "See https://docs.opencv.org/master/d7/d4d/tutorial_py_thresholding.html";
 
         public override string ConfirmationText =>
-            $"threshold pixels ({Threshold}/{Maximum}) from layers {LayerIndexStart} to {LayerIndexEnd}";
+            $"apply threshold {Threshold} with max {Maximum} from layers {LayerIndexStart} through {LayerIndexEnd}";
 
         public override string ProgressTitle =>
-            $"Thresholding pixels ({Threshold}/{Maximum}) from layers {LayerIndexStart} to {LayerIndexEnd}";
+            $"Applying threshold {Threshold} with max {Maximum} from layers {LayerIndexStart} through {LayerIndexEnd}";
 
         public override string ProgressAction => "Thresholded layers";
         

--- a/UVtools.GUI/Controls/CtrlKernel.Designer.cs
+++ b/UVtools.GUI/Controls/CtrlKernel.Designer.cs
@@ -28,6 +28,8 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(CtrlKernel));
             this.tbKernel = new System.Windows.Forms.TextBox();
             this.cbShape = new System.Windows.Forms.ComboBox();
             this.label1 = new System.Windows.Forms.Label();
@@ -38,17 +40,25 @@
             this.btnGen = new System.Windows.Forms.Button();
             this.btnReset = new System.Windows.Forms.Button();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
-            this.label4 = new System.Windows.Forms.Label();
+            this.label5 = new System.Windows.Forms.Label();
             this.nmAnchorY = new System.Windows.Forms.NumericUpDown();
             this.nmAnchorX = new System.Windows.Forms.NumericUpDown();
-            this.label5 = new System.Windows.Forms.Label();
-            this.label6 = new System.Windows.Forms.Label();
+            this.label4 = new System.Windows.Forms.Label();
+            this.toolTip = new System.Windows.Forms.ToolTip(this.components);
             ((System.ComponentModel.ISupportInitialize)(this.nmSizeX)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nmSizeY)).BeginInit();
             this.groupBox1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nmAnchorY)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nmAnchorX)).BeginInit();
             this.SuspendLayout();
+            // 
+            // toolTip
+            // 
+            this.toolTip.AutoPopDelay = 32767;
+            this.toolTip.InitialDelay = 500;
+            this.toolTip.ReshowDelay = 100;
+            this.toolTip.ToolTipIcon = System.Windows.Forms.ToolTipIcon.Info;
+            this.toolTip.ToolTipTitle = "Information";
             // 
             // tbKernel
             // 
@@ -60,6 +70,7 @@
             this.tbKernel.ScrollBars = System.Windows.Forms.ScrollBars.Both;
             this.tbKernel.Size = new System.Drawing.Size(210, 178);
             this.tbKernel.TabIndex = 1;
+            this.toolTip.SetToolTip(this.tbKernel, resources.GetString("tbKernel.ToolTip"));
             this.tbKernel.WordWrap = false;
             // 
             // cbShape
@@ -172,7 +183,6 @@
             // 
             // groupBox1
             // 
-            this.groupBox1.Controls.Add(this.label6);
             this.groupBox1.Controls.Add(this.label5);
             this.groupBox1.Controls.Add(this.nmAnchorY);
             this.groupBox1.Controls.Add(this.nmAnchorX);
@@ -194,15 +204,15 @@
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Kernel";
             // 
-            // label4
+            // label5
             // 
-            this.label4.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(223, 93);
-            this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(79, 20);
-            this.label4.TabIndex = 9;
-            this.label4.Text = "Anchor X:";
+            this.label5.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.label5.AutoSize = true;
+            this.label5.Location = new System.Drawing.Point(363, 93);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(24, 20);
+            this.label5.TabIndex = 12;
+            this.label5.Text = "Y:";
             // 
             // nmAnchorY
             // 
@@ -221,6 +231,7 @@
             this.nmAnchorY.Name = "nmAnchorY";
             this.nmAnchorY.Size = new System.Drawing.Size(50, 26);
             this.nmAnchorY.TabIndex = 11;
+            this.toolTip.SetToolTip(this.nmAnchorY, "Y coordinate of the kernel origin, -1 for auto-center");
             this.nmAnchorY.Value = new decimal(new int[] {
             1,
             0,
@@ -244,31 +255,22 @@
             this.nmAnchorX.Name = "nmAnchorX";
             this.nmAnchorX.Size = new System.Drawing.Size(50, 26);
             this.nmAnchorX.TabIndex = 10;
+            this.toolTip.SetToolTip(this.nmAnchorX, "X coordinate of the kenel origin, -1 for auto-center.");
             this.nmAnchorX.Value = new decimal(new int[] {
             1,
             0,
             0,
             -2147483648});
             // 
-            // label5
+            // label4
             // 
-            this.label5.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(363, 93);
-            this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(24, 20);
-            this.label5.TabIndex = 12;
-            this.label5.Text = "Y:";
-            // 
-            // label6
-            // 
-            this.label6.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.label6.AutoSize = true;
-            this.label6.Location = new System.Drawing.Point(222, 123);
-            this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(218, 20);
-            this.label6.TabIndex = 13;
-            this.label6.Text = "Note: Anchor auto center = -1";
+            this.label4.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.label4.AutoSize = true;
+            this.label4.Location = new System.Drawing.Point(223, 93);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(79, 20);
+            this.label4.TabIndex = 9;
+            this.label4.Text = "Anchor X:";
             // 
             // CtrlKernel
             // 
@@ -301,7 +303,7 @@
         private System.Windows.Forms.NumericUpDown nmAnchorY;
         private System.Windows.Forms.NumericUpDown nmAnchorX;
         private System.Windows.Forms.Label label4;
-        private System.Windows.Forms.Label label6;
         public System.Windows.Forms.TextBox tbKernel;
+        private System.Windows.Forms.ToolTip toolTip;
     }
 }

--- a/UVtools.GUI/Controls/CtrlKernel.resx
+++ b/UVtools.GUI/Controls/CtrlKernel.resx
@@ -117,4 +117,11 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <data name="tbKernel.ToolTip" xml:space="preserve">
+    <value>The kernel or structuring element used to probe the input image. 
+A structuring element is a matrix that identifies the pixel in the image being processed and defines the neighborhood used in the processing of each pixel.</value>
+  </data>
 </root>

--- a/UVtools.GUI/Controls/Tools/CtrlToolFlip.Designer.cs
+++ b/UVtools.GUI/Controls/Tools/CtrlToolFlip.Designer.cs
@@ -48,9 +48,11 @@
             this.cbMakeCopy.AutoSize = true;
             this.cbMakeCopy.Location = new System.Drawing.Point(240, 8);
             this.cbMakeCopy.Name = "cbMakeCopy";
-            this.cbMakeCopy.Size = new System.Drawing.Size(104, 24);
+            this.cbMakeCopy.Size = new System.Drawing.Size(120, 24);
             this.cbMakeCopy.TabIndex = 22;
-            this.cbMakeCopy.Text = "Make copy";
+            this.cbMakeCopy.Text = "Blend Layers";
+            this.toolTip.SetToolTip(this.cbMakeCopy, "If checked, rather than simply flipping the layer, a copy of each layer will be " +
+        "flipped and blended with the layer.");
             this.cbMakeCopy.UseVisualStyleBackColor = true;
             // 
             // cbFlipDirection
@@ -73,7 +75,7 @@
             this.Description = "";
             this.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Name = "CtrlToolFlip";
-            this.Size = new System.Drawing.Size(540, 45);
+            this.Size = new System.Drawing.Size(720, 45);
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/UVtools.GUI/Controls/Tools/CtrlToolMorph.Designer.cs
+++ b/UVtools.GUI/Controls/Tools/CtrlToolMorph.Designer.cs
@@ -59,6 +59,8 @@
             this.cbIterationsFade.Size = new System.Drawing.Size(108, 24);
             this.cbIterationsFade.TabIndex = 21;
             this.cbIterationsFade.Text = "Fade in/out";
+            this.toolTip.SetToolTip(this.cbIterationsFade, "Allow the number of iterations to be gradually varied as the operation progresses" +
+        " from the starting layer to the ending layer.");
             this.cbIterationsFade.UseVisualStyleBackColor = true;
             this.cbIterationsFade.CheckedChanged += new System.EventHandler(this.EventCheckedChanged);
             // 

--- a/UVtools.GUI/Controls/Tools/CtrlToolMove.Designer.cs
+++ b/UVtools.GUI/Controls/Tools/CtrlToolMove.Designer.cs
@@ -79,15 +79,15 @@
             this.groupBox1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.groupBox1.Location = new System.Drawing.Point(0, 0);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(571, 210);
+            this.groupBox1.Size = new System.Drawing.Size(720, 210);
             this.groupBox1.TabIndex = 24;
             this.groupBox1.TabStop = false;
-            this.groupBox1.Text = "Margins and Anchor";
+            this.groupBox1.Text = "Location && Margins";
             // 
             // lbInsideBounds
             // 
             this.lbInsideBounds.AutoSize = true;
-            this.lbInsideBounds.Location = new System.Drawing.Point(7, 168);
+            this.lbInsideBounds.Location = new System.Drawing.Point(7, 172);
             this.lbInsideBounds.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lbInsideBounds.Name = "lbInsideBounds";
             this.lbInsideBounds.Size = new System.Drawing.Size(147, 20);
@@ -97,42 +97,42 @@
             // lbPlacementY
             // 
             this.lbPlacementY.AutoSize = true;
-            this.lbPlacementY.Location = new System.Drawing.Point(7, 138);
+            this.lbPlacementY.Location = new System.Drawing.Point(7, 60);
             this.lbPlacementY.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lbPlacementY.Name = "lbPlacementY";
-            this.lbPlacementY.Size = new System.Drawing.Size(103, 20);
+            this.lbPlacementY.Size = new System.Drawing.Size(24, 20);
             this.lbPlacementY.TabIndex = 26;
-            this.lbPlacementY.Text = "Placement Y:";
+            this.lbPlacementY.Text = "Y:";
             // 
             // lbPlacementX
             // 
             this.lbPlacementX.AutoSize = true;
-            this.lbPlacementX.Location = new System.Drawing.Point(7, 107);
+            this.lbPlacementX.Location = new System.Drawing.Point(7, 31);
             this.lbPlacementX.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lbPlacementX.Name = "lbPlacementX";
-            this.lbPlacementX.Size = new System.Drawing.Size(103, 20);
+            this.lbPlacementX.Size = new System.Drawing.Size(24, 20);
             this.lbPlacementX.TabIndex = 25;
-            this.lbPlacementX.Text = "Placement X:";
+            this.lbPlacementX.Text = "X:";
             // 
             // lbVolumeHeight
             // 
             this.lbVolumeHeight.AutoSize = true;
-            this.lbVolumeHeight.Location = new System.Drawing.Point(7, 56);
+            this.lbVolumeHeight.Location = new System.Drawing.Point(7, 134);
             this.lbVolumeHeight.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lbVolumeHeight.Name = "lbVolumeHeight";
-            this.lbVolumeHeight.Size = new System.Drawing.Size(118, 20);
+            this.lbVolumeHeight.Size = new System.Drawing.Size(60, 20);
             this.lbVolumeHeight.TabIndex = 24;
-            this.lbVolumeHeight.Text = "Volume Height:";
+            this.lbVolumeHeight.Text = "Height:";
             // 
             // lbVolumeWidth
             // 
             this.lbVolumeWidth.AutoSize = true;
-            this.lbVolumeWidth.Location = new System.Drawing.Point(7, 27);
+            this.lbVolumeWidth.Location = new System.Drawing.Point(7, 103);
             this.lbVolumeWidth.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lbVolumeWidth.Name = "lbVolumeWidth";
-            this.lbVolumeWidth.Size = new System.Drawing.Size(112, 20);
+            this.lbVolumeWidth.Size = new System.Drawing.Size(54, 20);
             this.lbVolumeWidth.TabIndex = 23;
-            this.lbVolumeWidth.Text = "Volume Width:";
+            this.lbVolumeWidth.Text = "Width:";
             // 
             // label5
             // 
@@ -288,7 +288,9 @@
             this.nmMarginTop.Size = new System.Drawing.Size(85, 26);
             this.nmMarginTop.TabIndex = 15;
             this.nmMarginTop.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this.toolTip.SetToolTip(this.nmMarginTop, "Top margin in pixels");
             this.nmMarginTop.ValueChanged += new System.EventHandler(this.EventValueChanged);
+            this.nmMarginTop.KeyUp += new System.Windows.Forms.KeyEventHandler(this.EventValueChanged);
             // 
             // nmMarginBottom
             // 
@@ -307,7 +309,9 @@
             this.nmMarginBottom.Size = new System.Drawing.Size(85, 26);
             this.nmMarginBottom.TabIndex = 17;
             this.nmMarginBottom.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this.toolTip.SetToolTip(this.nmMarginBottom, "Bottom margin in pixels");
             this.nmMarginBottom.ValueChanged += new System.EventHandler(this.EventValueChanged);
+            this.nmMarginBottom.KeyUp += new System.Windows.Forms.KeyEventHandler(this.EventValueChanged);
             // 
             // label3
             // 
@@ -356,7 +360,9 @@
             this.nmMarginRight.Size = new System.Drawing.Size(85, 26);
             this.nmMarginRight.TabIndex = 19;
             this.nmMarginRight.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+            this.toolTip.SetToolTip(this.nmMarginRight, "Right margin in pixels");
             this.nmMarginRight.ValueChanged += new System.EventHandler(this.EventValueChanged);
+            this.nmMarginRight.KeyUp += new System.Windows.Forms.KeyEventHandler(this.EventValueChanged);
             // 
             // nmMarginLeft
             // 
@@ -374,8 +380,10 @@
             this.nmMarginLeft.Name = "nmMarginLeft";
             this.nmMarginLeft.Size = new System.Drawing.Size(85, 26);
             this.nmMarginLeft.TabIndex = 20;
+            this.toolTip.SetToolTip(this.nmMarginLeft, "Left Margin in pixels");
             this.nmMarginLeft.UpDownAlign = System.Windows.Forms.LeftRightAlignment.Left;
             this.nmMarginLeft.ValueChanged += new System.EventHandler(this.EventValueChanged);
+            this.nmMarginLeft.KeyUp += new System.Windows.Forms.KeyEventHandler(this.EventValueChanged);
             // 
             // CtrlToolMove
             // 
@@ -387,7 +395,7 @@
             this.ExtraButtonVisible = true;
             this.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Name = "CtrlToolMove";
-            this.Size = new System.Drawing.Size(571, 210);
+            this.Size = new System.Drawing.Size(720, 210);
             this.groupBox1.ResumeLayout(false);
             this.groupBox1.PerformLayout();
             this.tableAnchor.ResumeLayout(false);

--- a/UVtools.GUI/Controls/Tools/CtrlToolMove.cs
+++ b/UVtools.GUI/Controls/Tools/CtrlToolMove.cs
@@ -25,8 +25,8 @@ namespace UVtools.GUI.Controls.Tools
                 (uint)Program.FrmMain.ActualLayerImage.Height);
             SetOperation(Operation);
 
-            lbVolumeWidth.Text = $"Volume Width: {Operation.SrcRoi.Width} / {Operation.ImageWidth}";
-            lbVolumeHeight.Text = $"Volume Height: {Operation.SrcRoi.Height} / {Operation.ImageHeight}";
+            lbVolumeWidth.Text = $"Width: {Operation.SrcRoi.Width} / {Operation.ImageWidth}";
+            lbVolumeHeight.Text = $"Height: {Operation.SrcRoi.Height} / {Operation.ImageHeight}";
 
             ExtraActionCall(this);
         }
@@ -48,9 +48,9 @@ namespace UVtools.GUI.Controls.Tools
         {
             UpdateOperation();
             var insideBounds = ButtonOkEnabled = Operation.ValidateBounds();
-            lbInsideBounds.Text = "Inside Bounds: " + (insideBounds ? "Yes" : "No");
-            lbPlacementX.Text = $"Placement X: {Operation.DstRoi.X} / {Operation.ImageWidth - Operation.SrcRoi.Width}";
-            lbPlacementY.Text = $"Placement Y: {Operation.DstRoi.Y} / {Operation.ImageHeight - Operation.SrcRoi.Height}";
+            lbInsideBounds.Text = "Model within boundary: " + (insideBounds ? "Yes" : "No");
+            lbPlacementX.Text = $"X: {Operation.DstRoi.X} / {Operation.ImageWidth - Operation.SrcRoi.Width}";
+            lbPlacementY.Text = $"Y: {Operation.DstRoi.Y} / {Operation.ImageHeight - Operation.SrcRoi.Height}";
         }
 
         public override bool UpdateOperation()

--- a/UVtools.GUI/Controls/Tools/CtrlToolPattern.Designer.cs
+++ b/UVtools.GUI/Controls/Tools/CtrlToolPattern.Designer.cs
@@ -316,9 +316,9 @@
             this.lbInsideBounds.Location = new System.Drawing.Point(7, 139);
             this.lbInsideBounds.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lbInsideBounds.Name = "lbInsideBounds";
-            this.lbInsideBounds.Size = new System.Drawing.Size(147, 20);
+            this.lbInsideBounds.Size = new System.Drawing.Size(202, 20);
             this.lbInsideBounds.TabIndex = 46;
-            this.lbInsideBounds.Text = "Inside Bounds: Yes";
+            this.lbInsideBounds.Text = "Model within boundary: Yes";
             // 
             // lbRows
             // 
@@ -346,9 +346,9 @@
             this.lbVolumeHeight.Location = new System.Drawing.Point(4, 110);
             this.lbVolumeHeight.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lbVolumeHeight.Name = "lbVolumeHeight";
-            this.lbVolumeHeight.Size = new System.Drawing.Size(174, 20);
+            this.lbVolumeHeight.Size = new System.Drawing.Size(60, 20);
             this.lbVolumeHeight.TabIndex = 43;
-            this.lbVolumeHeight.Text = "Volume/Pattern Height:";
+            this.lbVolumeHeight.Text = "Height:";
             // 
             // lbVolumeWidth
             // 
@@ -356,9 +356,9 @@
             this.lbVolumeWidth.Location = new System.Drawing.Point(4, 81);
             this.lbVolumeWidth.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lbVolumeWidth.Name = "lbVolumeWidth";
-            this.lbVolumeWidth.Size = new System.Drawing.Size(168, 20);
+            this.lbVolumeWidth.Size = new System.Drawing.Size(54, 20);
             this.lbVolumeWidth.TabIndex = 42;
-            this.lbVolumeWidth.Text = "Volume/Pattern Width:";
+            this.lbVolumeWidth.Text = "Width:";
             // 
             // label4
             // 

--- a/UVtools.GUI/Controls/Tools/CtrlToolPattern.cs
+++ b/UVtools.GUI/Controls/Tools/CtrlToolPattern.cs
@@ -89,10 +89,10 @@ namespace UVtools.GUI.Controls.Tools
 
             var insideBounds = Operation.ValidateBounds();
             ButtonOkEnabled = insideBounds && (Operation.Cols > 1 || Operation.Rows > 1);
-            lbInsideBounds.Text = "Inside Bounds: " + (insideBounds ? "Yes" : "No");
+            lbInsideBounds.Text = "Model within boundary: " + (insideBounds ? "Yes" : "No");
 
-            lbVolumeWidth.Text = $"Volume/Pattern Width: {Operation.SrcRoi.Width} / {Operation.GetPatternVolume.Width} / {Operation.ImageWidth}";
-            lbVolumeHeight.Text = $"Volume/Pattern Height: {Operation.SrcRoi.Height} / {Operation.GetPatternVolume.Height} / {Operation.ImageHeight}";
+            lbVolumeWidth.Text = $"Width: {Operation.GetPatternVolume.Width} (Min:{Operation.SrcRoi.Width}, Max:{Operation.ImageWidth})";
+            lbVolumeHeight.Text = $"Height: {Operation.GetPatternVolume.Height} (Min:{Operation.SrcRoi.Height}, Max:{Operation.ImageHeight})";
 
             lbCols.Text = $"Columns: {nmCols.Value} / {Operation.MaxCols}";
             lbRows.Text = $"Rows: {nmRows.Value} / {Operation.MaxRows}";

--- a/UVtools.GUI/Controls/Tools/CtrlToolPixelDimming.Designer.cs
+++ b/UVtools.GUI/Controls/Tools/CtrlToolPixelDimming.Designer.cs
@@ -42,7 +42,6 @@
             this.nmInfillThickness = new System.Windows.Forms.NumericUpDown();
             this.label9 = new System.Windows.Forms.Label();
             this.label10 = new System.Windows.Forms.Label();
-            this.label6 = new System.Windows.Forms.Label();
             this.label5 = new System.Windows.Forms.Label();
             this.tbOddPattern = new System.Windows.Forms.TextBox();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
@@ -79,9 +78,9 @@
             this.cbDimsOnlyBorders.AutoSize = true;
             this.cbDimsOnlyBorders.Location = new System.Drawing.Point(301, 9);
             this.cbDimsOnlyBorders.Name = "cbDimsOnlyBorders";
-            this.cbDimsOnlyBorders.Size = new System.Drawing.Size(181, 24);
+            this.cbDimsOnlyBorders.Size = new System.Drawing.Size(146, 24);
             this.cbDimsOnlyBorders.TabIndex = 42;
-            this.cbDimsOnlyBorders.Text = "Dims only the borders";
+            this.cbDimsOnlyBorders.Text = "Dim only borders";
             this.cbDimsOnlyBorders.UseVisualStyleBackColor = true;
             // 
             // groupBox2
@@ -97,23 +96,21 @@
             this.groupBox2.Controls.Add(this.nmInfillThickness);
             this.groupBox2.Controls.Add(this.label9);
             this.groupBox2.Controls.Add(this.label10);
-            this.groupBox2.Location = new System.Drawing.Point(-1, 506);
+            this.groupBox2.Location = new System.Drawing.Point(-1, 476);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(575, 160);
+            this.groupBox2.Size = new System.Drawing.Size(575, 149);
             this.groupBox2.TabIndex = 41;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Infill generator";
             // 
             // label13
             // 
-            this.label13.Location = new System.Drawing.Point(7, 22);
+            this.label13.Location = new System.Drawing.Point(7, 30);
             this.label13.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label13.Name = "label13";
-            this.label13.Size = new System.Drawing.Size(561, 46);
+            this.label13.Size = new System.Drawing.Size(561, 30);
             this.label13.TabIndex = 34;
-            this.label13.Text = "The infill function can create a ton of resin traps, use only this tool if you kn" +
-    "ow what are you doing or for specific parts. You always need to ensure the drain" +
-    "s.";
+            this.label13.Text = "Warning: This function can genearte a large number of resin traps.";
             // 
             // label11
             // 
@@ -241,17 +238,6 @@
             this.label10.TabIndex = 21;
             this.label10.Text = "Thickness:";
             // 
-            // label6
-            // 
-            this.label6.AutoSize = true;
-            this.label6.Location = new System.Drawing.Point(6, 299);
-            this.label6.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(548, 20);
-            this.label6.TabIndex = 40;
-            this.label6.Text = "(Leave this field empty to use only the even layer pattern for the layers range)";
-            this.toolTip.SetToolTip(this.label6, resources.GetString("label6.ToolTip"));
-            // 
             // label5
             // 
             this.label5.AutoSize = true;
@@ -271,6 +257,7 @@
             this.tbOddPattern.Size = new System.Drawing.Size(469, 124);
             this.tbOddPattern.TabIndex = 38;
             this.tbOddPattern.Text = "255 255 127 255\r\n127 255 255 255";
+            this.toolTip.SetToolTip(this.tbOddPattern, "Leave this field empty in order to use only the even layer pattern.");
             this.tbOddPattern.WordWrap = false;
             // 
             // groupBox1
@@ -290,7 +277,7 @@
             this.groupBox1.Controls.Add(this.nmPixelDimBrightness);
             this.groupBox1.Controls.Add(this.label3);
             this.groupBox1.Controls.Add(this.label4);
-            this.groupBox1.Location = new System.Drawing.Point(-1, 338);
+            this.groupBox1.Location = new System.Drawing.Point(-1, 308);
             this.groupBox1.Name = "groupBox1";
             this.groupBox1.Size = new System.Drawing.Size(575, 162);
             this.groupBox1.TabIndex = 37;
@@ -524,7 +511,6 @@
             this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.Controls.Add(this.cbDimsOnlyBorders);
             this.Controls.Add(this.groupBox2);
-            this.Controls.Add(this.label6);
             this.Controls.Add(this.label5);
             this.Controls.Add(this.tbOddPattern);
             this.Controls.Add(this.groupBox1);
@@ -536,7 +522,7 @@
             this.Description = "";
             this.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Name = "CtrlToolPixelDimming";
-            this.Size = new System.Drawing.Size(577, 669);
+            this.Size = new System.Drawing.Size(577, 628);
             this.groupBox2.ResumeLayout(false);
             this.groupBox2.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nmInfillSpacing)).EndInit();
@@ -565,7 +551,6 @@
         private System.Windows.Forms.NumericUpDown nmInfillThickness;
         private System.Windows.Forms.Label label9;
         private System.Windows.Forms.Label label10;
-        private System.Windows.Forms.Label label6;
         private System.Windows.Forms.Label label5;
         private System.Windows.Forms.TextBox tbOddPattern;
         private System.Windows.Forms.GroupBox groupBox1;

--- a/UVtools.GUI/Controls/Tools/CtrlToolPixelDimming.resx
+++ b/UVtools.GUI/Controls/Tools/CtrlToolPixelDimming.resx
@@ -120,11 +120,6 @@
   <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <data name="label6.ToolTip" xml:space="preserve">
-    <value>Selects the layers range within start layer and end layer where mutator will operate.
-Select same layer start as end to operate only within that layer.
-Note: "Layer Start" start can't be higher than "Layer End".</value>
-  </data>
   <data name="label1.ToolTip" xml:space="preserve">
     <value>Selects the number of iterations/passes to perform on each layer using this mutator.
 Enable  the "Fade in/out" to fade the iteration over layers, you can use a start iteration higher than end to perform a inverse fade.
@@ -135,4 +130,7 @@ WARNING: Using high iteration values can destroy your model depending on the mut
 Enable  the "Fade in/out" to fade the iteration over layers, you can use a start iteration higher than end to perform a inverse fade.
 WARNING: Using high iteration values can destroy your model depending on the mutator being used, please use low values or with caution!</value>
   </data>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>25</value>
+  </metadata>
 </root>

--- a/UVtools.GUI/Controls/Tools/CtrlToolResize.Designer.cs
+++ b/UVtools.GUI/Controls/Tools/CtrlToolResize.Designer.cs
@@ -46,9 +46,11 @@
             this.cbFade.AutoSize = true;
             this.cbFade.Location = new System.Drawing.Point(8, 41);
             this.cbFade.Name = "cbFade";
-            this.cbFade.Size = new System.Drawing.Size(170, 24);
+            this.cbFade.Size = new System.Drawing.Size(283, 24);
             this.cbFade.TabIndex = 26;
-            this.cbFade.Text = "Fade towards 100%";
+            this.cbFade.Text = "Increase or decrease towards 100%";
+            this.toolTip.SetToolTip(this.cbFade, "If checked, resize will gradually adjust the scale factor from the percentage specified" +
+        " to 100% as the operation progresses from the starting layer to the ending layer.");
             this.cbFade.UseVisualStyleBackColor = true;
             // 
             // label2
@@ -80,9 +82,9 @@
             this.cbConstrainXY.CheckState = System.Windows.Forms.CheckState.Checked;
             this.cbConstrainXY.Location = new System.Drawing.Point(388, 8);
             this.cbConstrainXY.Name = "cbConstrainXY";
-            this.cbConstrainXY.Size = new System.Drawing.Size(126, 24);
+            this.cbConstrainXY.Size = new System.Drawing.Size(181, 24);
             this.cbConstrainXY.TabIndex = 23;
-            this.cbConstrainXY.Text = "Constrain X/Y";
+            this.cbConstrainXY.Text = "Constrain Proportions";
             this.cbConstrainXY.CheckedChanged += new System.EventHandler(this.EventValueChanged);
             // 
             // nmY
@@ -174,7 +176,7 @@
             this.Description = "";
             this.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Name = "CtrlToolResize";
-            this.Size = new System.Drawing.Size(540, 77);
+            this.Size = new System.Drawing.Size(720, 77);
             ((System.ComponentModel.ISupportInitialize)(this.nmY)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nmX)).EndInit();
             this.ResumeLayout(false);

--- a/UVtools.GUI/Controls/Tools/CtrlToolRotate.Designer.cs
+++ b/UVtools.GUI/Controls/Tools/CtrlToolRotate.Designer.cs
@@ -52,6 +52,8 @@
             this.nmDegrees.Name = "nmDegrees";
             this.nmDegrees.Size = new System.Drawing.Size(101, 26);
             this.nmDegrees.TabIndex = 23;
+            this.toolTip.SetToolTip(this.nmDegrees, "Number of degrees to rotate the layers, where postive values are clockwise and" +
+        " negative values are counter-clockwise.");
             this.nmDegrees.Value = new decimal(new int[] {
             90,
             0,

--- a/UVtools.GUI/Controls/Tools/CtrlToolThreshold.Designer.cs
+++ b/UVtools.GUI/Controls/Tools/CtrlToolThreshold.Designer.cs
@@ -28,68 +28,20 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.groupBox1 = new System.Windows.Forms.GroupBox();
-            this.btnPresetSetPixelsBrightness = new System.Windows.Forms.Button();
-            this.btnPresetFreeUse = new System.Windows.Forms.Button();
-            this.btnPresetStripAntiAliasing = new System.Windows.Forms.Button();
             this.nmMaximum = new System.Windows.Forms.NumericUpDown();
             this.label2 = new System.Windows.Forms.Label();
             this.nmThreshold = new System.Windows.Forms.NumericUpDown();
             this.label1 = new System.Windows.Forms.Label();
             this.cbThresholdType = new System.Windows.Forms.ComboBox();
-            this.groupBox1.SuspendLayout();
+            this.cbPresetHelpers = new System.Windows.Forms.ComboBox();
+            this.label3 = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.nmMaximum)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nmThreshold)).BeginInit();
             this.SuspendLayout();
             // 
-            // groupBox1
-            // 
-            this.groupBox1.Controls.Add(this.btnPresetSetPixelsBrightness);
-            this.groupBox1.Controls.Add(this.btnPresetFreeUse);
-            this.groupBox1.Controls.Add(this.btnPresetStripAntiAliasing);
-            this.groupBox1.Location = new System.Drawing.Point(8, 47);
-            this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(567, 77);
-            this.groupBox1.TabIndex = 24;
-            this.groupBox1.TabStop = false;
-            this.groupBox1.Text = "Presets / Helpers";
-            // 
-            // btnPresetSetPixelsBrightness
-            // 
-            this.btnPresetSetPixelsBrightness.BackColor = System.Drawing.SystemColors.Control;
-            this.btnPresetSetPixelsBrightness.Location = new System.Drawing.Point(338, 25);
-            this.btnPresetSetPixelsBrightness.Name = "btnPresetSetPixelsBrightness";
-            this.btnPresetSetPixelsBrightness.Size = new System.Drawing.Size(223, 36);
-            this.btnPresetSetPixelsBrightness.TabIndex = 2;
-            this.btnPresetSetPixelsBrightness.Text = "Set pixels brightness";
-            this.btnPresetSetPixelsBrightness.UseVisualStyleBackColor = false;
-            this.btnPresetSetPixelsBrightness.Click += new System.EventHandler(this.EventClick);
-            // 
-            // btnPresetFreeUse
-            // 
-            this.btnPresetFreeUse.BackColor = System.Drawing.SystemColors.Control;
-            this.btnPresetFreeUse.Location = new System.Drawing.Point(6, 25);
-            this.btnPresetFreeUse.Name = "btnPresetFreeUse";
-            this.btnPresetFreeUse.Size = new System.Drawing.Size(160, 36);
-            this.btnPresetFreeUse.TabIndex = 1;
-            this.btnPresetFreeUse.Text = "Free use";
-            this.btnPresetFreeUse.UseVisualStyleBackColor = false;
-            this.btnPresetFreeUse.Click += new System.EventHandler(this.EventClick);
-            // 
-            // btnPresetStripAntiAliasing
-            // 
-            this.btnPresetStripAntiAliasing.BackColor = System.Drawing.SystemColors.Control;
-            this.btnPresetStripAntiAliasing.Location = new System.Drawing.Point(172, 25);
-            this.btnPresetStripAntiAliasing.Name = "btnPresetStripAntiAliasing";
-            this.btnPresetStripAntiAliasing.Size = new System.Drawing.Size(160, 36);
-            this.btnPresetStripAntiAliasing.TabIndex = 0;
-            this.btnPresetStripAntiAliasing.Text = "Strip AntiAliasing";
-            this.btnPresetStripAntiAliasing.UseVisualStyleBackColor = false;
-            this.btnPresetStripAntiAliasing.Click += new System.EventHandler(this.EventClick);
-            // 
             // nmMaximum
             // 
-            this.nmMaximum.Location = new System.Drawing.Point(305, 7);
+            this.nmMaximum.Location = new System.Drawing.Point(305, 51);
             this.nmMaximum.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.nmMaximum.Maximum = new decimal(new int[] {
             255,
@@ -108,7 +60,7 @@
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(251, 10);
+            this.label2.Location = new System.Drawing.Point(251, 54);
             this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(46, 20);
@@ -117,7 +69,7 @@
             // 
             // nmThreshold
             // 
-            this.nmThreshold.Location = new System.Drawing.Point(109, 7);
+            this.nmThreshold.Location = new System.Drawing.Point(109, 51);
             this.nmThreshold.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.nmThreshold.Maximum = new decimal(new int[] {
             255,
@@ -136,7 +88,7 @@
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(4, 10);
+            this.label1.Location = new System.Drawing.Point(4, 54);
             this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(83, 20);
@@ -147,18 +99,40 @@
             // 
             this.cbThresholdType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cbThresholdType.FormattingEnabled = true;
-            this.cbThresholdType.Location = new System.Drawing.Point(437, 6);
+            this.cbThresholdType.Location = new System.Drawing.Point(437, 50);
             this.cbThresholdType.Name = "cbThresholdType";
             this.cbThresholdType.Size = new System.Drawing.Size(138, 28);
             this.cbThresholdType.TabIndex = 19;
+            // 
+            // cbPresetHelpers
+            // 
+            this.cbPresetHelpers.FormattingEnabled = true;
+            this.cbPresetHelpers.Items.AddRange(new object[] {
+            "Free use",
+            "Strip AntiAliasing",
+            "Set pixel brightness"});
+            this.cbPresetHelpers.Location = new System.Drawing.Point(128, 10);
+            this.cbPresetHelpers.Name = "cbPresetHelpers";
+            this.cbPresetHelpers.Size = new System.Drawing.Size(212, 28);
+            this.cbPresetHelpers.TabIndex = 25;
+            this.cbPresetHelpers.SelectedIndexChanged += new System.EventHandler(this.cbPresetHelpers_SelectedIndexChanged);
+            // 
+            // label3
+            // 
+            this.label3.AutoSize = true;
+            this.label3.Location = new System.Drawing.Point(4, 13);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(118, 20);
+            this.label3.TabIndex = 26;
+            this.label3.Text = "Preset Helpers:";
             // 
             // CtrlToolThreshold
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoSize = true;
-            this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.Controls.Add(this.groupBox1);
+            this.Controls.Add(this.label3);
+            this.Controls.Add(this.cbPresetHelpers);
             this.Controls.Add(this.nmMaximum);
             this.Controls.Add(this.label2);
             this.Controls.Add(this.nmThreshold);
@@ -167,8 +141,7 @@
             this.Description = "";
             this.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Name = "CtrlToolThreshold";
-            this.Size = new System.Drawing.Size(578, 127);
-            this.groupBox1.ResumeLayout(false);
+            this.Size = new System.Drawing.Size(578, 82);
             ((System.ComponentModel.ISupportInitialize)(this.nmMaximum)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nmThreshold)).EndInit();
             this.ResumeLayout(false);
@@ -177,15 +150,12 @@
         }
 
         #endregion
-
-        private System.Windows.Forms.GroupBox groupBox1;
-        private System.Windows.Forms.Button btnPresetSetPixelsBrightness;
-        private System.Windows.Forms.Button btnPresetFreeUse;
-        private System.Windows.Forms.Button btnPresetStripAntiAliasing;
         private System.Windows.Forms.NumericUpDown nmMaximum;
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.NumericUpDown nmThreshold;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.ComboBox cbThresholdType;
+        private System.Windows.Forms.ComboBox cbPresetHelpers;
+        private System.Windows.Forms.Label label3;
     }
 }

--- a/UVtools.GUI/Controls/Tools/CtrlToolThreshold.cs
+++ b/UVtools.GUI/Controls/Tools/CtrlToolThreshold.cs
@@ -33,6 +33,8 @@ namespace UVtools.GUI.Controls.Tools
             cbThresholdType.EndUpdate();
             
             cbThresholdType.SelectedItem = ThresholdType.Binary;
+
+            cbPresetHelpers.SelectedItem = "Free use";
         }
 
         public override bool UpdateOperation()
@@ -44,9 +46,9 @@ namespace UVtools.GUI.Controls.Tools
             return true;
         }
 
-        private void EventClick(object sender, EventArgs e)
+        private void cbPresetHelpers_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (ReferenceEquals(sender, btnPresetFreeUse))
+            if (cbPresetHelpers.SelectedItem.ToString() == "Free use")
             {
                 nmThreshold.Enabled =
                     nmMaximum.Enabled =
@@ -54,9 +56,12 @@ namespace UVtools.GUI.Controls.Tools
                 return;
             }
 
-            if (ReferenceEquals(sender, btnPresetStripAntiAliasing))
+            if (cbPresetHelpers.SelectedItem.ToString() == "Strip AntiAliasing")
             {
-                EventClick(btnPresetFreeUse, e);
+                nmThreshold.Enabled =
+                    nmMaximum.Enabled =
+                        cbThresholdType.Enabled = true;
+
                 nmMaximum.Enabled = cbThresholdType.Enabled = false;
 
                 nmThreshold.Value = 127;
@@ -66,9 +71,12 @@ namespace UVtools.GUI.Controls.Tools
                 return;
             }
 
-            if (ReferenceEquals(sender, btnPresetSetPixelsBrightness))
+            if (cbPresetHelpers.SelectedItem.ToString() == "Set pixel brightness")
             {
-                EventClick(btnPresetFreeUse, e);
+                nmThreshold.Enabled =
+                    nmMaximum.Enabled =
+                        cbThresholdType.Enabled = true;
+
                 nmThreshold.Enabled = cbThresholdType.Enabled = false;
 
                 nmThreshold.Value = 254;


### PR DESCRIPTION
Mostly text updates, with a few adjustments to dialog box layouts or controls.

For example, preset helpers for Threshold operation were changed from buttons to a combobox selections.

Allowed the line splits added by Designer to remain, but did fix any mid-word breaks, removed empty tool-tips, etc.