### PR TITLE
Updates to building from source for Windows

### DIFF
--- a/CompileWindows.bat
+++ b/CompileWindows.bat
@@ -2,6 +2,7 @@
 SET DIR=%~dp0
 
 REM if exist "%SYSTEMROOT%\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe" SET MSBUILD_PATH="%SYSTEMROOT%\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe"
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\MSBuild.exe" SET MSBUILD_PATH="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\MSBuild.exe"
 if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe" SET MSBUILD_PATH="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe"
 
 IF [%MSBUILD_PATH%] == [] GOTO noMSBuild

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ This simple tool can give you insight of supports and find some failures. Did yo
 ![Convertion Screenshot](https://raw.githubusercontent.com/sn4k3/UVtools/master/UVtools.GUI/Images/Screenshots/SL1ToCbddlp.png)
 
 # Why this project?
-I don't own a Prusa SL1 or any other resin printer, for now I’m only a FDM user with 
+I don't own a Prusa SL1 or any other resin printer, for now Iâ€™m only a FDM user with 
 Prusa MK3 and a Ender3.
 PrusaSlicer is my only choose, why? Because I think it's the best and feature more, 
 at least for me, simple but powerful. 
 
-So why this project? Well in fact I’m looking for a resin printer and i like to study 
+So why this project? Well in fact Iâ€™m looking for a resin printer and i like to study 
 and learn first before buy, get good and don't regret, and while inspecting i found that 
 resin printers firmwares are not as universal as FDM, too many file formats and there 
 before each printer can use their own property file, this of course limit the software selection,
@@ -403,6 +403,13 @@ There are multiple ways to open your file:
 # Library -> Developers
 
 Are you a developer? This project include a .NET 5.0 library (UVtools.Core) that can be referenced in your application to make use of my work. Easy to use calls that allow you work with the formats. For more information navigate main code.
+
+## Windows Build from Source
+Install Visual Studio and include .NET development support
+Install the Wix Toolset: https://wixtoolset.org/releases/ 
+   you will need both the core Wix toolset and the VS extension pack which is selected AFTER the main installation has completed (or from the main release page).
+Open UVtools.sln
+If required update the .NET developer pack VS will prompt on opening if needed (it's the lower section on the web page - something like .NET Framework 4.8)
 
 
 # TODO

--- a/README.md
+++ b/README.md
@@ -406,9 +406,13 @@ Are you a developer? This project include a .NET 5.0 library (UVtools.Core) that
 
 ## Windows Build from Source
 Install Visual Studio and include .NET development support
+
 Install the Wix Toolset: https://wixtoolset.org/releases/ 
+
    you will need both the core Wix toolset and the VS extension pack which is selected AFTER the main installation has completed (or from the main release page).
+   
 Open UVtools.sln
+
 If required update the .NET developer pack VS will prompt on opening if needed (it's the lower section on the web page - something like .NET Framework 4.8)
 
 


### PR DESCRIPTION
These are minor updates to guide building from source code. It isn't quite complete as I'm still getting an error when attempting to build
Error		Project '..\UVtools.Core\UVtools.Core.csproj' targets 'net5.0'. It cannot be referenced by a project that targets '.NETFramework,Version=v4.8'.	UVtools.GUI			

PS I don't know why github thinks I changed the Why this project section in README.md as I only added a small section at the bottom of this file