### PR TITLE
Add Encrypt/Decrypt CTB command line

### DIFF
--- a/UVtools.WPF/ConsoleArguments.cs
+++ b/UVtools.WPF/ConsoleArguments.cs
@@ -141,6 +141,14 @@ namespace UVtools.WPF
                 return true;
             }
 
+            if (args[0] is "--encrypt-ctb" or "--decrypt-ctb")
+            {
+                bool isEncrypt = (args[0] is "--encrypt-ctb");
+
+
+                CTBEncryptedFile.CryptFile(args[1], isEncrypt);
+                return true;
+            }
 
             return false;
         }


### PR DESCRIPTION
--decrypt-ctb <filepath> will decrypt all encrypted fields in the CTB. The file is replaced with the decrypted contents.

--encrypt-ctb <filepath> will encrypt header and footers of the CTB. No layer data is encrypted (not required). The file is replaced with the encrypted contents.