### PR TITLE
New Resin Trap/Suction Cup detection algorithm

### DIFF
--- a/UVtools.WPF/MainWindow.LayerPreview.cs
+++ b/UVtools.WPF/MainWindow.LayerPreview.cs
@@ -978,6 +978,28 @@ namespace UVtools.WPF
                             continue;
                         }
 
+                        if (issue.Type == LayerIssue.IssueType.SuctionCup)
+                        {
+                            color = selectedIssues.Count > 0 && selectedIssues.Contains(issue)
+                                ? Settings.LayerPreview.SuctionCupHighlightColor
+                                : Settings.LayerPreview.SuctionCupColor;
+
+
+                            using (var vec = new VectorOfVectorOfPoint(issue.Contours))
+                            {
+                                CvInvoke.DrawContours(LayerCache.ImageBgr, vec, -1, new MCvScalar(color.B, color.G, color.R), -1);
+                            }
+
+                            if (_showLayerImageCrosshairs &&
+                                !Settings.LayerPreview.CrosshairShowOnlyOnSelectedIssues &&
+                                LayerImageBox.Zoom <= AppSettings.CrosshairFadeLevel)
+                            {
+                                DrawCrosshair(issue.BoundingRectangle);
+                            }
+
+                            continue;
+                        }
+
                         switch (issue.Type)
                         {
                             case LayerIssue.IssueType.Island:


### PR DESCRIPTION
This implements a novel resin/suction trap detection for MSLA sliced images.

It largely consists of 2 passes through the layers. 
 
The 1st pass processes the layers from the bottom to the top, keeping track of what areas in 
the previous layer are air (or connected to air in some way). The initial air map is derived from
the starting layer, by inverting the layer and then filling all external contours black (not air)
which results in an initial air map of everything that is not solid, or inside a solid, being considered
air. While traversing the layers, the air map is updated to include any new air regions, or hollow areas
that intersect with the air map (since while they are not air, they are connected to air). Any regions 
that do not overlap the air map are declared resin traps.

The 2nd pass processes the layers from the top to the bottom, the initial air map differs from
the 1st pass. For the 2nd pass, anything that is not solid is considered to be air (a bitwise 
not of the top layer is used). The airmap is updated per layer just like it was in the 1st pass,
however we do not test all contours of the layer, only those that were marked as resin traps by 
the 1st pass. This is acceptable because in the event we did test all hollow areas, and one of those
was *not* detected on 1st pass, it must be air-accessible from the bottom. In the even that a contour
we are testing does overlap the air map during the 2nd pass, it is cleared from the "resin trap" list
and instead added to the "suction trap" list. This is to indicate that while there is access to air from
the top, there are regions that could be affected by vacuum/suction forces during the print