### PR TITLE
Dedup contours during merging of resinTrapGroups.

### DIFF
--- a/UVtools.Core/Managers/IssueManager.cs
+++ b/UVtools.Core/Managers/IssueManager.cs
@@ -850,7 +850,7 @@ namespace UVtools.Core.Managers
                                     var overlappingGroupIndexes = new List<int>();
                                     for (var groupIndex = 0; groupIndex < resinTrapGroups.Count; groupIndex++)
                                     {
-                                        if (resinTrapGroups[groupIndex].Last().layerIndex != layerIndex + 1) continue;
+                                        if (resinTrapGroups[groupIndex][^1].layerIndex != layerIndex + 1 && resinTrapGroups[groupIndex][^1].layerIndex != layerIndex) continue;
 
                                         if (EmguContours.ContoursIntersect(resinTrapGroups[groupIndex].Last().contour,
                                             resinTraps[layerIndex][x]))

--- a/UVtools.Core/Managers/IssueManager.cs
+++ b/UVtools.Core/Managers/IssueManager.cs
@@ -871,23 +871,10 @@ namespace UVtools.Core.Managers
                                     else
                                     {
                                         var combinedGroup = new List<(VectorOfVectorOfPoint contour, uint layerIndex)>();
-
-                                        /* for reasons not fully understood, in rare cases you can end up with the same contour in multiple groups that are 
-                                         * about to merge. This can cause a use-after-free type error later on when we dispose of a contour.
-                                         * We can (at least in the short term) remedy this by de-duping the result of the merge */
-                                        var uniqueCombinedGroup = new HashSet<(VectorOfVectorOfPoint contour, uint layerIndex)>();
                                         foreach (var index in overlappingGroupIndexes)
                                         {
-                                            foreach (var p in resinTrapGroups[index])
-                                            {
-                                                uniqueCombinedGroup.Add(p);
-                                            }
+                                            combinedGroup.AddRange(resinTrapGroups[index]);
                                         }
-                                        combinedGroup.AddRange(uniqueCombinedGroup.ToList());
-                                        combinedGroup.Add((resinTraps[layerIndex][x], (uint)layerIndex));
-
-                                        uniqueCombinedGroup.Clear();
-                                        uniqueCombinedGroup = null;
 
                                         for (var index = overlappingGroupIndexes.Count - 1; index >= 0; index--)
                                         {
@@ -895,6 +882,7 @@ namespace UVtools.Core.Managers
                                             resinTrapGroups.RemoveAt(index);
                                         }
 
+                                        combinedGroup.Add((resinTraps[layerIndex][x], (uint)layerIndex));
                                         resinTrapGroups.Add(combinedGroup);
                                     }
                                 }

--- a/UVtools.Core/Managers/IssueManager.cs
+++ b/UVtools.Core/Managers/IssueManager.cs
@@ -871,10 +871,23 @@ namespace UVtools.Core.Managers
                                     else
                                     {
                                         var combinedGroup = new List<(VectorOfVectorOfPoint contour, uint layerIndex)>();
+
+                                        /* for reasons not fully understood, in rare cases you can end up with the same contour in multiple groups that are 
+                                         * about to merge. This can cause a use-after-free type error later on when we dispose of a contour.
+                                         * We can (at least in the short term) remedy this by de-duping the result of the merge */
+                                        var uniqueCombinedGroup = new HashSet<(VectorOfVectorOfPoint contour, uint layerIndex)>();
                                         foreach (var index in overlappingGroupIndexes)
                                         {
-                                            combinedGroup.AddRange(resinTrapGroups[index]);
+                                            foreach (var p in resinTrapGroups[index])
+                                            {
+                                                uniqueCombinedGroup.Add(p);
+                                            }
                                         }
+                                        combinedGroup.AddRange(uniqueCombinedGroup.ToList());
+                                        combinedGroup.Add((resinTraps[layerIndex][x], (uint)layerIndex));
+
+                                        uniqueCombinedGroup.Clear();
+                                        uniqueCombinedGroup = null;
 
                                         for (var index = overlappingGroupIndexes.Count - 1; index >= 0; index--)
                                         {
@@ -882,7 +895,6 @@ namespace UVtools.Core.Managers
                                             resinTrapGroups.RemoveAt(index);
                                         }
 
-                                        combinedGroup.Add((resinTraps[layerIndex][x], (uint)layerIndex));
                                         resinTrapGroups.Add(combinedGroup);
                                     }
                                 }


### PR DESCRIPTION
Fix for edge case where a contour is in multiple groups and they get merged. Doesn't fix root cause of the contour being placed in 2 groups, but for the time being this works around it be deduping during the merge