### PR TITLE
Improve size for generated Wavefront OBJ files

### DIFF
--- a/UVtools.Core/MeshFormats/MeshFile.cs
+++ b/UVtools.Core/MeshFormats/MeshFile.cs
@@ -67,6 +67,7 @@ namespace UVtools.Core.MeshFormats
         /// </summary>
         public FileStream MeshStream { get; }
 
+        public uint VertexCount { get; protected set; }
         /// <summary>
         /// Gets the number of triangles
         /// </summary>

--- a/UVtools.Core/MeshFormats/OBJMeshFile.cs
+++ b/UVtools.Core/MeshFormats/OBJMeshFile.cs
@@ -6,6 +6,7 @@
  *  of this license document, but changing it is not allowed.
  */
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Numerics;
 using System.Text;
@@ -18,6 +19,7 @@ namespace UVtools.Core.MeshFormats
     {
         #region Constants
         public const string DefaultObjectName = "Object.1";
+        const int VertexCacheSize = 3000;
         #endregion
 
         #region Properties
@@ -32,16 +34,23 @@ namespace UVtools.Core.MeshFormats
             ObjectName = name ?? DefaultObjectName;
         }
 
-        public OBJMeshFile(string filePath, FileMode fileMode, MeshFileFormat fileFormat) : this(filePath, fileMode, fileFormat, DefaultObjectName) { }
+        public OBJMeshFile(string filePath, FileMode fileMode, MeshFileFormat fileFormat) : this(filePath, fileMode, MeshFileFormat.ASCII, DefaultObjectName) { }
         
         public OBJMeshFile(string filePath, FileMode fileMode) : this(filePath, fileMode, MeshFileFormat.ASCII, DefaultObjectName) { }
 
-        
+
+        #endregion
+
+        #region Members
+        Dictionary<Vector3, uint> VertexCache = new Dictionary<Vector3, uint>(VertexCacheSize);
+        StreamWriter triangleStream = null;
         #endregion
 
         #region Methods
         public override void BeginWrite()
         {
+            /* Create a stream to store the triangles (faces) as they come through */
+            triangleStream = File.CreateText(FilePath + ".tris");
             MeshStream.WriteLine($"# {HeaderComment}");
             MeshStream.WriteLine($"o {ObjectName}");
             MeshStream.WriteLine();
@@ -50,25 +59,52 @@ namespace UVtools.Core.MeshFormats
 
         public override void WriteTriangle(Vector3 p1, Vector3 p2, Vector3 p3, Vector3 normal)
         {
-            MeshStream.WriteLine($"v {p1.X:F6} {p1.Y:F6} {p1.Z:F6}");
-            MeshStream.WriteLine($"v {p2.X:F6} {p2.Y:F6} {p2.Z:F6}");
-            MeshStream.WriteLine($"v {p3.X:F6} {p3.Y:F6} {p3.Z:F6}");
+            if (!VertexCache.ContainsKey(p1))
+            {
+                MeshStream.WriteLine($"v {p1.X:F6} {p1.Y:F6} {p1.Z:F6}");
+                VertexCount++;
+                VertexCache.Add(p1, VertexCount);
+            }
+            if (!VertexCache.ContainsKey(p2))
+            {
+                MeshStream.WriteLine($"v {p2.X:F6} {p2.Y:F6} {p2.Z:F6}");
+                VertexCount++;
+                VertexCache.Add(p2, VertexCount);
+            }
+            if (!VertexCache.ContainsKey(p3))
+            {
+                MeshStream.WriteLine($"v {p3.X:F6} {p3.Y:F6} {p3.Z:F6}");
+                VertexCount++;
+                VertexCache.Add(p3, VertexCount);
+            }
 
-            TriangleCount++;
+            triangleStream.WriteLine($"f {VertexCache[p1]} {VertexCache[p2]} {VertexCache[p3]}");
+            
+            /* If we are getting close to the cache size. we do *not* want to go over the capacity as that will trigger
+             * an allocation of a bigger buffer and copy of the kvp's */
+            if (VertexCache.Count >= VertexCacheSize - 10)
+            {
+                VertexCache.Clear();
+            }
         }
 
         public override void EndWrite()
         {
+            VertexCache.Clear();
             MeshStream.WriteLine();
             MeshStream.WriteLine("# Polygonal face elements");
 
-            uint count = TriangleCount * 3;
-            for (var i = 1; i <= count;)
-            {
-                MeshStream.WriteLine($"f {i++} {i++} {i++}");
-            }
+            /* Make sure all triangles are flushed to disk */
+            triangleStream.Flush();
+            triangleStream.Close();
 
-            MeshStream.WriteLine();
+            /* copy the triangles to the main OBJ mesh file */
+            var fileReader = File.OpenRead(FilePath + ".tris");
+            fileReader.CopyTo(MeshStream);
+            fileReader.Close();
+            fileReader.Dispose();
+            File.Delete(FilePath + ".tris");
+
             MeshStream.WriteLine($"# Triangles: {TriangleCount}");
         }
 


### PR DESCRIPTION
Implement a 3,000 vertex cache to try and re-use vertex points when generating the faces. 3,000 was arbitrarily chosen and could be changed in the future.