### PR TITLE
Enable desktop integration for AppImages

### DIFF
--- a/build/platforms/linux/AppImage/UVtools.desktop
+++ b/build/platforms/linux/AppImage/UVtools.desktop
@@ -6,6 +6,4 @@ Name=UVtools
 Comment=MSLA/DLP, file analysis, calibration, repair, conversion and manipulation
 Icon=UVtools
 Exec=UVtools
-Path=~
-Terminal=true
 Categories=Utility;


### PR DESCRIPTION
## What does the pull request do?

Restores ability to integrate AppImages into the desktop.


## What is the current behavior?

Older AppImages (2.2x) could be desktop-integrated by tools like AppImageLauncher. Since then, the desktop file was changed to include `Terminal=true`. For obvious reasons, terminal applications should not be integrated, and thus are ignored by libappimage-based tools.


## What is the updated/expected behavior with this PR?

Marks AppImage as UI tool, thus allowing AppImages to be integrated again.

The PR also removes the superfluous/broken `Path` setting.

(For the record, the desktop file template on the referenced wiki page is wrong there.)


## How was the solution implemented (if it's not obvious)?

Remove offending key(s) from the desktop file does the trick.


## Fixed issues

Didn't feel like I had to create an issue first, it's a minor fix, really.