### PR TITLE
Update Readme for Ubuntu 22.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,10 +252,21 @@ The following commands are the old way and commands under the UI executable, the
 1. 1920 x 1080 @ 100% scale as minimum resolution
 
 ### Ubuntu/Mint/Debian/Similars
+*Install Dependencies*
 
+- Ubuntu 20.04
 ```bash
 sudo apt-get update
 sudo apt-get install -y libjpeg-dev libpng-dev libgeotiff-dev libgeotiff5 libdc1394-22 libavcodec-dev libavformat-dev libswscale-dev libopenexr24 libtbb-dev libgl1-mesa-dev libgdiplus wget
+```
+- Ubuntu 22.04 (brings `libdc1394-25` instead of `-22` and `libopenexr25` instead of `libopenexr24`
+```bash
+sudo apt update
+sudo apt install -y libjpeg-dev libpng-dev libgeotiff-dev libgeotiff5 libdc1394-25 libavcodec-dev libavformat-dev libswscale-dev libopenexr25 libtbb-dev libgl1-mesa-dev libgdiplus wget
+```
+
+- Fix libdl symlink
+```
 wget -qO - https://raw.githubusercontent.com/sn4k3/UVtools/master/Scripts/libdl-solver.sh | sudo bash
 ```
 


### PR DESCRIPTION
Ubuntu 22.04 replaced `libdc1394-22` with `-25` and `libopenexr25` with `libopenexr25`. This means the tried-and-true "Copy readme to shell" no longer works. To accommodate for this we update the Readme for Ubuntu 22.04 as long as 20.04 is still in support. 21.10 and 21.04 are already EOL so we dont explicitly mention them here even tho they are also shipping with different library versions but should no longer be used.

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Update the Readme

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Readme works to transport the information of the required libraries but does not longer work out of the box.

## What is the updated/expected behavior with this PR?
<!--- Also describe how to test the PR. -->
Readme should provide 1to1 instructions if an ubuntu section is already implemented