### PR TITLE
Add in PartitionExposureArray for AnycubicZipFile.LcdRerfFunction

### DIFF
--- a/UVtools.Core/FileFormats/AnycubicZipFile.cs
+++ b/UVtools.Core/FileFormats/AnycubicZipFile.cs
@@ -697,9 +697,9 @@ public sealed class AnycubicZipFile : FileFormat
         [JsonPropertyName("model_type")]
         public int ModelType { get; set; } = 1;
 
-        // TODO: Find this
-        //[JsonPropertyName("partition_exposure_array")]
-        //public int PartitionExposureArray { get; set; }
+        // Exposure times for each partition
+        [JsonPropertyName("partition_exposure_array")]
+        public float[] PartitionExposureArray { get; set; } = [];
 
         [JsonPropertyName("partition_num")]
         public int PartitionNum { get; set; }


### PR DESCRIPTION
## What does the pull request do?
Add in PartitionExposureArray for AnycubicZipFile.LcdRerfFunction

## What is the current behavior?
Current implementation omits details, causing Photon Workshop slicer to treat file as invalid.

## What is the updated/expected behavior with this PR?
Anycubic Photon Workshop slicer requires the array. 

Tested on MacOS by saving file and opening using Photon Workshop V4.1.6 __20260526143256.


## How was the solution implemented (if it's not obvious)?
Type info obtained from Exposure Calibration file generated for Photon P1.

## Fixed issues
Close #1108

