### PR TITLE
chore: gitignore the NUKE temp directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,10 @@ project.lock.json
 project.fragment.lock.json
 artifacts/
 
+# NUKE
+# Holds the .NET SDK build.ps1/build.sh downloads when no suitable one is installed
+.nuke/temp/
+
 # Tye
 .tye/
 


### PR DESCRIPTION
TITLE: chore: gitignore the NUKE temp directory

## What does the pull request do?

Adds `.nuke/temp/` to `.gitignore`.

## What is the current behavior?

`build.ps1` / `build.sh` download a full .NET SDK into `.nuke/temp` when no suitable
one is already installed. The directory is not ignored, so every working copy that has
run the build script once shows several hundred megabytes of untracked files in
`git status` forever after.

## What is the updated/expected behavior with this PR?

`.nuke/temp/` no longer appears as untracked.

To test: run `build.cmd` (or `build.sh`) on a machine without a matching SDK so the
script downloads one, then check `git status` is clean.

## How was the solution implemented (if it's not obvious)?

The entry is scoped to `.nuke/temp/` rather than `.nuke/` so that the tracked
`.nuke/build.schema.json` and `.nuke/parameters.json` sitting alongside it keep
showing up in status and diffs.
