### PR TITLE
Rename "010" solution folder to work around Nuke source generator bug

### DIFF
--- a/UVtools.slnx
+++ b/UVtools.slnx
@@ -41,7 +41,7 @@
     <File Path="Scripts/install-dependencies.sh" />
     <File Path="Scripts/install-uvtools.sh" />
   </Folder>
-  <Folder Name="/root/scripts/010/">
+  <Folder Name="/root/scripts/Editor010/">
     <File Path="Scripts/010 Editor/anet.bt" />
     <File Path="Scripts/010 Editor/ctb.bt" />
     <File Path="Scripts/010 Editor/ctb_decrypted.bt" />


### PR DESCRIPTION
TITLE: fix: rename the "010" solution folder so the NUKE solution generator emits valid code

PS: Wrote with the help of AI but reviewed and tested by a human... :-)

## What does the pull request do?

Renames the `/root/scripts/010/` solution folder in `UVtools.slnx` to
`/root/scripts/Editor010/`, working around a code generation bug in
NUKE 10.1.0 that currently breaks `build.cmd` / `build.ps1`.

## What is the current behavior?

Running `build.cmd` or `build.ps1` fails before any target executes:

```
artifacts/obj/build/debug/Nuke.SourceGenerators/Nuke.SourceGenerators.StronglyTypedSolutionGenerator/Solution.g.cs(52,20):
error CS0246: The type or namespace name '____10' could not be found
```

`Build.cs` uses `[Solution(GenerateProjects = true)]`, so NUKE's
`StronglyTypedSolutionGenerator` emits a nested class per solution folder,
prefixing one underscore per nesting level. For a folder name starting with a
digit it sanitizes the *property* name by replacing the leading digit with an
underscore (`010` -> `_10`), but declares the *class* from the raw name. The
reference and the declaration therefore disagree:

```csharp
public ____10 _10 => Unsafe.As<____10>(this.GetSolutionFolder("010"));   // line 52
internal class ___010(...) : SolutionFolder(...)                         // line 54
```

Plain `dotnet build` of the application projects is unaffected; only the NUKE
build host fails to compile.

## What is the updated/expected behavior with this PR?

`build.cmd` / `build.ps1` compile the build project and run targets again.

To test: `build.cmd Print` (or any target) — it previously failed with CS0246,
now it runs.

## How was the solution implemented (if it's not obvious)?

The folder name is a display name only. The `<File Path="Scripts/010 Editor/..." />`
entries beneath it are untouched, so nothing moves on disk and no project
reference changes — the diff is one line.

`Editor010` rather than `010 Editor` because a space would produce an equally
invalid identifier (`___010 Editor`); the name must avoid both a leading digit
and whitespace.

This is a defect in NUKE itself and worth reporting upstream to nuke-build/nuke —
any repository with a digit-leading solution folder hits it. The rename is a
reasonable permanent workaround regardless.
