### PR TITLE
Avoid eager pixel lists during island detection

### DIFF
--- a/UVtools.Core/Managers/IssueManager.cs
+++ b/UVtools.Core/Managers/IssueManager.cs
@@ -499,7 +499,11 @@ public sealed class IssueManager : RangeObservableCollection<MainIssue>
                                         previousSpan = previousImage.RoiMat.GetReadOnlySpan2DOfBytes();
                                     }
 
-                                    List<Point> points = [];
+                                    // First pass only counts. The point list is materialized later, and only
+                                    // for components that actually turn out to be islands: a large solid
+                                    // cross-section would otherwise grow (and immediately discard) a list with
+                                    // one entry per pixel.
+                                    int pixelCount = 0;
                                     uint pixelsSupportingIsland = 0;
 
                                     for (int y = rect.Y; y < rect.Bottom; y++)
@@ -509,7 +513,7 @@ public sealed class IssueManager : RangeObservableCollection<MainIssue>
                                             roiSpan.DangerousGetReferenceAt(y, x) < islandConfig.RequiredPixelBrightnessToProcessCheck // Low brightness, ignore
                                         ) continue;
 
-                                        points.Add(new Point(image.Roi.X + x, image.Roi.Y + y));
+                                        pixelCount++;
 
                                         //int pixel = roiStep * y + x;
                                         if (previousSpan.DangerousGetReferenceAt(y, x) >= islandConfig.RequiredPixelBrightnessToSupport)
@@ -518,9 +522,9 @@ public sealed class IssueManager : RangeObservableCollection<MainIssue>
                                         }
                                     }
 
-                                    if (points.Count == 0) continue; // Should never happen
+                                    if (pixelCount == 0) continue; // Should never happen
 
-                                    var requiredSupportingPixels = Math.Max(1, points.Count * islandConfig.RequiredPixelsToSupportMultiplier);
+                                    var requiredSupportingPixels = Math.Max(1, pixelCount * islandConfig.RequiredPixelsToSupportMultiplier);
 
                                     /*if (pixelsSupportingIsland >= islandConfig.RequiredPixelsToSupport)
                                             isIsland = false; // Not a island, bounding is strong, i think...
@@ -582,6 +586,18 @@ public sealed class IssueManager : RangeObservableCollection<MainIssue>
                                         {
                                             continue;
                                         }
+                                    }
+
+                                    // Confirmed island: now collect its pixels.
+                                    var points = new List<Point>(pixelCount);
+                                    for (int y = rect.Y; y < rect.Bottom; y++)
+                                    for (int x = rect.X; x < rect.Right; x++)
+                                    {
+                                        if (labelSpan.DangerousGetReferenceAt(y, x) != i ||
+                                            roiSpan.DangerousGetReferenceAt(y, x) < islandConfig.RequiredPixelBrightnessToProcessCheck
+                                        ) continue;
+
+                                        points.Add(new Point(image.Roi.X + x, image.Roi.Y + y));
                                     }
 
                                     AddIssue(new MainIssue(MainIssue.IssueType.Island, new IssueOfPoints(layer, points, islandBoundingRectangle)));


### PR DESCRIPTION
## What does the pull request do?

Reduces island-detection memory use by delaying construction of each component's pixel list until after the component is confirmed to be an island.

## What is the current behavior?

The detector creates and fills a `List<Point>` for every connected component before checking whether the previous layer supports it. Large, supported cross-sections therefore allocate one `Point` per lit pixel even though the list is immediately discarded.

This can produce many gigabytes of short-lived managed allocations, high peak memory use, and avoidable garbage-collection work during issue detection.

## What is the updated/expected behavior with this PR?

The first scan only counts candidate and supporting pixels. A correctly sized point list is created and populated only for a component that has passed the support checks and will be reported as an island.

Detection results are unchanged.

## How was the solution implemented?

The existing component scan now records `pixelCount` instead of appending points. Once the component is confirmed as an island, its pixels are collected in a second scan into a list pre-sized to that count.

Release-build benchmark on an anonymized 1,379-layer, 1620 x 2560 test model, median of three runs:

| Islands-only detection | Upstream master | This PR |
| --- | ---: | ---: |
| Time | 3.42 s | 1.26 s |
| Managed allocations | 16.94 GB | 12.5 MB |
| Peak working set | 3.55 GB | 1.96 GB |

That is about 2.7x faster for island detection, with more than 99.9% fewer managed allocation bytes. All four representative test files produced identical island counts and hashes before and after the change.

For context, an all-detectors run on the same model improved from 15.7 s to 13.3 s, while managed allocations fell from 16.99 GB to 57.9 MB.

`UVtools.Core` builds successfully. The full test project currently fails to compile on the unmodified upstream base because `OperationPCBExposureTests` still references the removed `FlipY` property; this PR does not touch that unrelated existing failure.

Related: #1112
