### PR TITLE
Fix empty-layer classification in linear time

### DIFF
--- a/UVtools.Core/Managers/IssueManager.cs
+++ b/UVtools.Core/Managers/IssueManager.cs
@@ -196,49 +196,44 @@ public sealed class IssueManager : RangeObservableCollection<MainIssue>
 
         if (emptyLayerConfig.Enabled)
         {
+            var classifyByPosition = emptyLayerConfig.IgnoreStartingEmptyLayers ||
+                                     emptyLayerConfig.IgnoreLooseEmptyLayers ||
+                                     emptyLayerConfig.IgnoreEndingEmptyLayers;
+            var firstNonEmptyLayerIndex = 0;
+            var lastNonEmptyLayerIndex = SlicerFile.Count - 1;
+            if (classifyByPosition)
+            {
+                while (firstNonEmptyLayerIndex < SlicerFile.Count && SlicerFile[firstNonEmptyLayerIndex].IsEmpty)
+                {
+                    firstNonEmptyLayerIndex++;
+                }
+
+                while (lastNonEmptyLayerIndex >= firstNonEmptyLayerIndex && SlicerFile[lastNonEmptyLayerIndex].IsEmpty)
+                {
+                    lastNonEmptyLayerIndex--;
+                }
+            }
+
             for (var layerIndex = 0; layerIndex < SlicerFile.Count; layerIndex++)
             {
                 var layer = SlicerFile[layerIndex];
                 if (!layer.IsEmpty) continue;
 
-                if (!emptyLayerConfig.IgnoreStartingEmptyLayers
-                    && emptyLayerConfig is {IgnoreLooseEmptyLayers: false, IgnoreEndingEmptyLayers: false})
+                if (!classifyByPosition)
                 {
                     AddIssue(new MainIssue(MainIssue.IssueType.EmptyLayer, new Issue(layer)));
                     continue;
                 }
 
-                // 1 = Starting
-                // 2 = Loose
-                // 3 = Ending
-                byte emptyLayerPosType = 0;
-                int i;
-
-                for (i = 0; i < layerIndex && SlicerFile[i].IsEmpty; layerIndex++) { }
-
-                if (i == layerIndex)
+                if (layerIndex < firstNonEmptyLayerIndex)
                 {
-                    emptyLayerPosType = 1;
+                    if (!emptyLayerConfig.IgnoreStartingEmptyLayers) AddIssue(new MainIssue(MainIssue.IssueType.EmptyLayer, new Issue(layer)));
                 }
-                else
-                {
-                    for (i = (int) SlicerFile.LastLayerIndex; i > layerIndex && SlicerFile[i].IsEmpty; layerIndex--) { }
-                    emptyLayerPosType = i == layerIndex ? (byte) 3 : (byte) 2;
-                }
-
-                if (emptyLayerPosType == 1)
-                {
-                    if(!emptyLayerConfig.IgnoreStartingEmptyLayers) AddIssue(new MainIssue(MainIssue.IssueType.EmptyLayer, new Issue(layer)));
-                }
-                else if (emptyLayerPosType == 2)
-                {
-                    if (!emptyLayerConfig.IgnoreLooseEmptyLayers) AddIssue(new MainIssue(MainIssue.IssueType.EmptyLayer, new Issue(layer)));
-                }
-                else if (emptyLayerPosType == 3)
+                else if (layerIndex > lastNonEmptyLayerIndex)
                 {
                     if (!emptyLayerConfig.IgnoreEndingEmptyLayers) AddIssue(new MainIssue(MainIssue.IssueType.EmptyLayer, new Issue(layer)));
                 }
-                else
+                else if (!emptyLayerConfig.IgnoreLooseEmptyLayers)
                 {
                     AddIssue(new MainIssue(MainIssue.IssueType.EmptyLayer, new Issue(layer)));
                 }

--- a/tests/UVtools.Tests/EmptyLayerDetectionTests.cs
+++ b/tests/UVtools.Tests/EmptyLayerDetectionTests.cs
@@ -1,0 +1,86 @@
+/*
+ *                     GNU AFFERO GENERAL PUBLIC LICENSE
+ *                       Version 3, 19 November 2007
+ *  Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ *  Everyone is permitted to copy and distribute verbatim copies
+ *  of this license document, but changing it is not allowed.
+ */
+
+using System;
+using System.Drawing;
+using System.Linq;
+using System.Threading.Tasks;
+using Emgu.CV;
+using Emgu.CV.CvEnum;
+using Emgu.CV.Structure;
+using UVtools.Core.FileFormats;
+using UVtools.Core.Layers;
+using UVtools.Core.Operations;
+using Xunit;
+
+namespace UVtools.Tests;
+
+public class EmptyLayerDetectionTests
+{
+    private static FileFormat CreateFile(params bool[] solidLayers)
+    {
+        var slicerFile = PcbFixtures.CreateSlicerFile();
+        var layers = new Layer[solidLayers.Length];
+        for (var i = 0; i < layers.Length; i++)
+        {
+            using var mat = new Mat(slicerFile.Resolution, DepthType.Cv8U, 1);
+            mat.SetTo(new MCvScalar(0));
+            if (solidLayers[i])
+            {
+                CvInvoke.Rectangle(mat, new Rectangle(400, 400, 200, 200), new MCvScalar(255), -1);
+            }
+
+            layers[i] = new Layer((uint)i, mat, slicerFile);
+        }
+
+        slicerFile.Init(layers);
+        return slicerFile;
+    }
+
+    private static uint[] DetectEmptyLayers(FileFormat slicerFile, bool ignoreStarting, bool ignoreLoose,
+        bool ignoreEnding)
+    {
+        var config = new IssuesDetectionConfiguration();
+        config.DisableAll();
+        config.EmptyLayerConfig.Enabled = true;
+        config.EmptyLayerConfig.IgnoreStartingEmptyLayers = ignoreStarting;
+        config.EmptyLayerConfig.IgnoreLooseEmptyLayers = ignoreLoose;
+        config.EmptyLayerConfig.IgnoreEndingEmptyLayers = ignoreEnding;
+
+        var detection = Task.Run(() => slicerFile.IssueManager.DetectIssues(config, new OperationProgress()));
+        Assert.True(detection.Wait(TimeSpan.FromSeconds(30)), "Empty-layer detection did not finish.");
+
+        return detection.Result
+            .Where(issue => issue.Type == MainIssue.IssueType.EmptyLayer)
+            .Select(issue => issue.StartLayerIndex)
+            .OrderBy(index => index)
+            .ToArray();
+    }
+
+    [Fact]
+    public void EmptyLayersAreClassifiedAsStartingLooseOrEnding()
+    {
+        // 0,1 empty (starting) | 2 solid | 3 empty (loose) | 4 solid | 5,6 empty (ending)
+        using var slicerFile = CreateFile(false, false, true, false, true, false, false);
+
+        Assert.Equal(new uint[] { 0, 1, 3, 5, 6 }, DetectEmptyLayers(slicerFile, false, false, false));
+        Assert.Equal(new uint[] { 3, 5, 6 }, DetectEmptyLayers(slicerFile, true, false, false));
+        Assert.Equal(new uint[] { 0, 1, 5, 6 }, DetectEmptyLayers(slicerFile, false, true, false));
+        Assert.Equal(new uint[] { 0, 1, 3 }, DetectEmptyLayers(slicerFile, false, false, true));
+        Assert.Empty(DetectEmptyLayers(slicerFile, true, true, true));
+    }
+
+    [Fact]
+    public void AllEmptyLayersAreClassifiedAsStarting()
+    {
+        using var slicerFile = CreateFile(false, false, false);
+
+        Assert.Equal(new uint[] { 0, 1, 2 }, DetectEmptyLayers(slicerFile, false, true, true));
+        Assert.Empty(DetectEmptyLayers(slicerFile, true, false, false));
+    }
+}


### PR DESCRIPTION
## What does the pull request do?

Fixes empty-layer position classification so Detect Issues no longer hangs on runs of starting or ending empty layers, and changes the classifier from repeated scans to a linear-time pass.

## What is the current behavior?

The starting- and ending-layer scans increment or decrement the outer `layerIndex` instead of their local scan cursor. With the corresponding ignore options enabled, a run containing multiple starting or ending empty layers can therefore loop until integer overflow instead of finishing.

Correcting only those cursor updates still rescans from the beginning or end for every empty layer, producing quadratic behavior for long empty-layer runs.

## What is the updated/expected behavior with this PR?

Starting, loose, and ending empty layers are classified correctly for every combination of their ignore options. All-empty files are treated as containing starting empty layers.

Regression tests cover starting, loose, ending, and all-empty files and use a timeout so the original non-termination is caught.

For a synthetic 1×1 file with a run of leading empty layers followed by one non-empty layer, three-run alternating medians for Detect Issues were:

| Leading empty layers | Corrected quadratic classifier | This PR | Speedup |
|---:|---:|---:|---:|
| 16,000 | 201.9 ms | 47.9 ms | 4.2× |
| 32,000 | 738.7 ms | 47.9 ms | 15.4× |
| 64,000 | 3.089 s | 48.7 ms | 63× |

The comparison baseline fixes only the incorrect cursor updates in current master, allowing the same input to complete while preserving its repeated-scan algorithm.

All 58 repository tests pass when run with the unrelated `FlipVertically` test-project repair currently required by master.

## How was the solution implemented (if it is not obvious)?

When positional filtering is needed, the classifier finds the first and last non-empty layer once. Each empty layer is then categorized with constant-time index comparisons during the existing layer pass.
